### PR TITLE
Fix memory cache: preserve entry when iCloud EDEADLK prevents file read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `memory_cache.invalidate()` wrongly deleted a valid cache entry (or skipped adding a new one) when iCloud returned EDEADLK while reading the file. The fix checks `path.exists()` before deleting: if the file is present but unreadable the old entry is preserved and the update is retried on the next 60-second sweep cycle. This prevented overdue commitments (and other recently-written files) from appearing in morning briefings when iCloud was actively syncing (#75).
+- Briefing: unparseable `due_date` values (e.g. `"Unknown"`) now emit a `log.warning` instead of silently dropping the commitment, making future date-format bugs diagnosable in the logs.
+
 ## [1.10.1] — 2026-04-28
 
 ### Fixed

--- a/memory_cache.py
+++ b/memory_cache.py
@@ -380,7 +380,12 @@ class MemoryCache:
         text = await read_text_with_retry_async(path, default=None)
 
         if text is None:
-            # File missing — delete row
+            if path.exists():
+                # File is present on disk but unreadable — iCloud EDEADLK most likely.
+                # Keep the existing cache row (if any) and let the next sweep retry.
+                log.warning("invalidate: %s — exists but unreadable, will retry", filename)
+                return
+            # File is genuinely gone — remove it from cache.
             self._conn.execute("DELETE FROM memories WHERE filename = ?", (filename,))
             self._conn.commit()
             return

--- a/notification_manager.py
+++ b/notification_manager.py
@@ -373,12 +373,17 @@ class NotificationManager:
             if not due_date_str:
                 continue
             try:
-                due_date = datetime.fromisoformat(due_date_str).date()
+                due_date = datetime.fromisoformat(str(due_date_str)).date()
                 if due_date == today:
                     due_today.append(fm)
                 elif due_date < today:
                     overdue.append(fm)
             except Exception:
+                log.warning(
+                    "briefing: unparseable due_date %r in %s — skipping",
+                    due_date_str,
+                    fm.get("source_title", "?"),
+                )
                 continue
 
         if due_today:

--- a/tests/unit/test_memory_cache.py
+++ b/tests/unit/test_memory_cache.py
@@ -527,8 +527,8 @@ async def test_corrupt_db_recovery(tmp_path, memories_dir):
 
 
 @pytest.mark.asyncio
-async def test_edeadlk_handling(cache_db, memories_dir):
-    """EDEADLK simulation: retry helper handles it gracefully."""
+async def test_edeadlk_skips_when_file_exists(cache_db, memories_dir):
+    """EDEADLK on a file that exists: invalidate skips (not delete), retries later."""
     from memory_cache import MemoryCache
 
     _write_memory(
@@ -540,37 +540,55 @@ async def test_edeadlk_handling(cache_db, memories_dir):
 
     cache = MemoryCache(cache_db, memories_dir)
 
-    # Patch read_text_with_retry_async to raise EDEADLK once, then succeed
-    call_count = 0
+    async def mock_read_fail(path, default=None):
+        return default  # Simulate persistent EDEADLK
 
-    async def mock_read(path, default=None):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            # First call: simulate EDEADLK → should return default
-            return default
-        # Second call: succeed
-        return path.read_text()
-
-    with patch("memory_cache.read_text_with_retry_async", side_effect=mock_read):
-        # First invalidate → EDEADLK → skips
+    with patch("memory_cache.read_text_with_retry_async", side_effect=mock_read_fail):
         await cache.invalidate("2026-04-25-test-abc123.md")
 
-        # Cache should be empty (file wasn't added)
-        conn = sqlite3.connect(str(cache_db))
-        count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
-        conn.close()
-        # Since default=None, invalidate sees None and tries to DELETE (no-op if not present)
-        assert count == 0
+    # File exists on disk but was unreadable — cache should be empty (skipped, not deleted)
+    conn = sqlite3.connect(str(cache_db))
+    count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+    conn.close()
+    assert count == 0
 
-    # Reset call count and try again (second call succeeds)
-    call_count = 0
-    with patch("memory_cache.read_text_with_retry_async", side_effect=mock_read):
-        await cache.invalidate("2026-04-25-test-abc123.md")
-
-    # Now should be populated (second attempt)
+    # On next sweep when file becomes readable, it should get indexed
+    await cache.invalidate("2026-04-25-test-abc123.md")
     entry = await cache.get("2026-04-25-test-abc123.md")
     assert entry is not None
+
+    cache.close()
+
+
+@pytest.mark.asyncio
+async def test_edeadlk_preserves_existing_cache_entry(cache_db, memories_dir):
+    """EDEADLK during update preserves the old (valid) cache row."""
+    from memory_cache import MemoryCache
+
+    _write_memory(
+        memories_dir,
+        "2026-04-25-test-abc123.md",
+        {"type": "commitment"},
+        "Original body"
+    )
+
+    cache = MemoryCache(cache_db, memories_dir)
+    # Populate cache with the original content
+    await cache.invalidate("2026-04-25-test-abc123.md")
+    entry_before = await cache.get("2026-04-25-test-abc123.md")
+    assert entry_before is not None
+
+    # Simulate EDEADLK on a subsequent update attempt
+    async def mock_read_fail(path, default=None):
+        return default
+
+    with patch("memory_cache.read_text_with_retry_async", side_effect=mock_read_fail):
+        await cache.invalidate("2026-04-25-test-abc123.md")
+
+    # Old entry must still be present — EDEADLK must not delete valid cached data
+    entry_after = await cache.get("2026-04-25-test-abc123.md")
+    assert entry_after is not None
+    assert entry_after["body"] == entry_before["body"]
 
     cache.close()
 


### PR DESCRIPTION
## Summary

- **Root cause of #75**: `memory_cache.invalidate()` treated `None` from `read_text_with_retry_async` as "file deleted" and ran `DELETE`, but `None` also means iCloud EDEADLK (file exists, temporarily unreadable). Files that hit EDEADLK during sweep were never added to the cache — and existing valid cache entries were wiped on subsequent EDEADLK hits. This caused overdue commitments (e.g. `commitment-submit-360-feedback`) to disappear from morning briefings during iCloud sync storms.
- **Secondary fix**: Unparseable `due_date` values (e.g. `"Unknown"`) in briefing assembly now emit `log.warning` instead of silently dropping the commitment, making future format bugs diagnosable.

## Changes

- **`memory_cache.py`**: In `invalidate()`, check `path.exists()` before deleting the cache row. If the file exists but is unreadable (EDEADLK), log a warning and return — the 60-second sweep loop will retry. Only delete when the file is genuinely gone.
- **`notification_manager.py`**: Add `log.warning` for unparseable `due_date` in briefing assembly; also wrap bare `str()` around `due_date_str` before `fromisoformat()` to handle YAML date objects.
- **`tests/unit/test_memory_cache.py`**: Replace previous `test_edeadlk_handling` (which validated the broken behaviour) with two new tests:
  - `test_edeadlk_skips_when_file_exists` — EDEADLK on a never-cached file: skip (not delete), succeed on next attempt
  - `test_edeadlk_preserves_existing_cache_entry` — EDEADLK during update: old cache entry must survive

## Test plan

- [x] `pytest` — 1372 passed, 0 failed
- [x] `test_edeadlk_skips_when_file_exists` covers the "new file, EDEADLK, retry later" path
- [x] `test_edeadlk_preserves_existing_cache_entry` covers the "valid entry wiped by EDEADLK update" path
- [x] `test_invalidate_missing_file` still passes — genuine delete path unchanged

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)