### PR TITLE
feat(/changes): add project/goal activity digest command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `/changes [hours]` Telegram command: scans all active goals and projects, finds related memory files updated in the last N hours (default 24, max 168), and sends a concise LLM-generated activity digest per item — one paragraph per project/goal with recent activity. Implemented in `GoalProjectAgent.generate_change_digest()` (#74).
+
 ### Fixed
 - `skill_executor`: `AuthenticationError` from LiteLLM now returns `None` immediately and logs an ERROR — the fallback model is never tried when the API key itself is bad (#59).
 - `skill_executor`: `PermissionDeniedError` (model-tier/entitlement 403) now falls back to the next configured model instead of hard-stopping, so skills with cross-provider fallbacks degrade gracefully when the preferred model is unavailable to the current key (#59).

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -169,6 +169,7 @@ class TelegramChatHandler:
         self.app.add_handler(CommandHandler("milestone", self.cmd_milestone))
         self.app.add_handler(CommandHandler("linkgoal", self.cmd_linkgoal))
         self.app.add_handler(CommandHandler("unlinkgoal", self.cmd_unlinkgoal))
+        self.app.add_handler(CommandHandler("changes", self.cmd_changes))
         # Skill management
         self.app.add_handler(CommandHandler("skill_drafts", self.cmd_skill_drafts))
         self.app.add_handler(CommandHandler("skill_draft", self.cmd_skill_draft))
@@ -3072,6 +3073,56 @@ class TelegramChatHandler:
         except Exception as e:
             log.exception("Error in cmd_unlinkgoal")
             await update.message.reply_text(f"Error unlinking goal: {_safe_error(e)}")
+
+    # ── /changes command ──────────────────────────────────────────────────────
+
+    async def cmd_changes(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Show project/goal activity digest for the last N hours (default 24)."""
+        if not self._check_auth(update):
+            return
+
+        hours = 24
+        if context.args:
+            try:
+                hours = int(context.args[0])
+                if hours < 1 or hours > 168:
+                    await update.message.reply_text("Hours must be between 1 and 168.")
+                    return
+            except ValueError:
+                await update.message.reply_text("Usage: /changes [hours]  e.g. /changes 48")
+                return
+
+        await update.message.reply_text(f"Scanning activity for the last {hours}h…")
+
+        from goal_project_agent import GoalProjectAgent
+        agent = GoalProjectAgent(role="full", cache=self._cache)
+
+        try:
+            results = await agent.generate_change_digest(hours=hours)
+        except Exception as e:
+            log.exception("Error in cmd_changes")
+            await update.message.reply_text(f"Error generating digest: {_safe_error(e)}")
+            return
+
+        if not results:
+            await update.message.reply_text(
+                f"No project/goal activity in the last {hours}h."
+            )
+            return
+
+        header = f"Project/goal activity — last {hours}h ({len(results)} item{'s' if len(results) != 1 else ''})\n"
+        parts = [header]
+        for i, item in enumerate(results, 1):
+            icon = "\U0001f3af" if item["type"] == "goal" else "\U0001f4cb"
+            count = item["memory_count"]
+            count_str = f"{count} update{'s' if count != 1 else ''}"
+            parts.append(
+                f"{i}. {icon} {item['title']}  ({count_str})\n{item['summary']}"
+            )
+
+        msg = "\n\n".join(parts)
+        for chunk in [msg[i : i + TG_MAX_CHARS] for i in range(0, len(msg), TG_MAX_CHARS)]:
+            await update.message.reply_text(chunk)
 
     # ── /contacts command ─────────────────────────────────────────────────────
 

--- a/command_core.py
+++ b/command_core.py
@@ -67,6 +67,7 @@ COMMAND_REGISTRY: dict[str, list[tuple[str, str]]] = {
         ("milestone",       "Toggle milestone M on project N: /milestone N M"),
         ("linkgoal",        "Link project N to goal M: /linkgoal N M"),
         ("unlinkgoal",      "Unlink project N from its goal"),
+        ("changes",         "Project/goal activity digest for the last N hours. /changes [hours] (default 24)"),
     ],
     "Review": [
         ("review",   "List pending project/repo candidates (/review N for detail)"),

--- a/goal_project_agent.py
+++ b/goal_project_agent.py
@@ -772,3 +772,86 @@ class GoalProjectAgent:
                 await asyncio.wait_for(stop_event.wait(), timeout=interval)
             except asyncio.TimeoutError:
                 pass
+
+    # ── On-demand change digest ───────────────────────────────────────────────
+
+    async def _generate_digest_summary(
+        self,
+        title: str,
+        item_fm: dict,
+        related_memories: list,
+        hours: int,
+    ) -> str:
+        """Return a 2–3 sentence plain-text summary of recent activity for one item."""
+        related_snippets = []
+        for mem_path, mem_fm in related_memories:
+            date_str = (
+                mem_fm.get("created")
+                or mem_fm.get("meeting_date")
+                or mem_fm.get("last_message")
+                or ""
+            )
+            date_str = str(date_str)[:10]
+            mem_title = mem_fm.get("source_title", mem_path.name)
+            mem_summary = mem_fm.get("summary", "")[:200]
+            related_snippets.append(f"- [{date_str}] {mem_title} — {mem_summary}")
+
+        item_type = item_fm.get("type", "goal")
+        status = item_fm.get("status", "")
+        prompt = (
+            f"{item_type.capitalize()}: {title} (status: {status})\n\n"
+            f"Related activity in the last {hours}h ({len(related_memories)} items):\n"
+            + "\n".join(related_snippets)
+            + "\n\nWrite 2–3 sentences of plain text summarising what changed or happened "
+            "for this project/goal. Focus on concrete activity, decisions, or progress. "
+            "No headers or bullets. Be specific and concise."
+        )
+
+        try:
+            from litellm import acompletion
+            resp = await acompletion(
+                model=resolve("summarize"),
+                messages=[{"role": "user", "content": prompt}],
+                timeout=20,
+            )
+            return resp.choices[0].message.content.strip()
+        except Exception as e:
+            log.warning("Digest summary LLM call failed for %s: %s", title, e)
+            titles = [
+                mem_fm.get("source_title", p.name)
+                for p, mem_fm in related_memories[:3]
+            ]
+            return f"{len(related_memories)} related activit{'ies' if len(related_memories) != 1 else 'y'}: {', '.join(titles)}"
+
+    async def generate_change_digest(self, hours: int = 24) -> list:
+        """Return activity digest for active goals/projects with changes in the last N hours.
+
+        Each entry is a dict with keys: title, type, summary, memory_count.
+        Entries are sorted by memory_count descending (most active first).
+        Returns an empty list when no items have recent activity.
+        """
+        cutoff_iso = (datetime.now() - timedelta(hours=hours)).isoformat()
+
+        items = await self._select_items()
+        results = []
+
+        for item_path, item_fm in items:
+            related = await self._find_related_memories(
+                item_path, item_fm, last_checked=cutoff_iso
+            )
+            if not related:
+                continue
+
+            title = item_fm.get("source_title", item_path.stem)
+            summary = await self._generate_digest_summary(title, item_fm, related, hours)
+            results.append(
+                {
+                    "title": title,
+                    "type": item_fm.get("type", "goal"),
+                    "summary": summary,
+                    "memory_count": len(related),
+                }
+            )
+
+        results.sort(key=lambda x: x["memory_count"], reverse=True)
+        return results

--- a/tests/integration/test_e2e_projects.py
+++ b/tests/integration/test_e2e_projects.py
@@ -115,3 +115,14 @@ async def test_unlinkgoal_smoke(handler, mk_update, brain_dir):
     update2, ctx2 = mk_update("/unlinkgoal", args=["1"])
     await handler.cmd_unlinkgoal(update2, ctx2)
     update2.message.reply_text.assert_called()
+
+
+async def test_changes_smoke(handler, mk_update):
+    """Smoke: /changes runs without error even when there are no active projects."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    mock_agent = MagicMock()
+    mock_agent.generate_change_digest = AsyncMock(return_value=[])
+    update, ctx = mk_update("/changes")
+    with patch("goal_project_agent.GoalProjectAgent", return_value=mock_agent):
+        await handler.cmd_changes(update, ctx)
+    update.message.reply_text.assert_called()

--- a/tests/unit/test_chat_handler.py
+++ b/tests/unit/test_chat_handler.py
@@ -4995,3 +4995,73 @@ async def test_cmd_briefing_awaits_assemble_briefing(handler):
     # Verify it was called with the resolved string, not a coroutine object
     arg = update.message.reply_text.call_args[0][0]
     assert isinstance(arg, str), f"reply_text received {type(arg)} instead of str — missing await?"
+
+
+# ── /changes tests ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_cmd_changes_no_activity(handler, brain_dir):
+    """/changes when no projects have recent activity shows the 'no activity' message."""
+    from unittest.mock import AsyncMock as _AsyncMock
+    mock_agent = MagicMock()
+    mock_agent.generate_change_digest = _AsyncMock(return_value=[])
+
+    update, context = _make_update(12345, args=[])
+    with patch("goal_project_agent.GoalProjectAgent", return_value=mock_agent):
+        await handler.cmd_changes(update, context)
+
+    calls = [c[0][0] for c in update.message.reply_text.call_args_list]
+    assert any("No project/goal activity" in t for t in calls)
+
+
+@pytest.mark.asyncio
+async def test_cmd_changes_shows_digest(handler, brain_dir):
+    """/changes with results formats each entry with title and summary."""
+    from unittest.mock import AsyncMock as _AsyncMock
+    digest = [
+        {"title": "Alpha Project", "type": "project", "summary": "Work was done.", "memory_count": 2},
+        {"title": "My Goal", "type": "goal", "summary": "Progress made.", "memory_count": 1},
+    ]
+    mock_agent = MagicMock()
+    mock_agent.generate_change_digest = _AsyncMock(return_value=digest)
+
+    update, context = _make_update(12345, args=[])
+    with patch("goal_project_agent.GoalProjectAgent", return_value=mock_agent):
+        await handler.cmd_changes(update, context)
+
+    all_text = " ".join(c[0][0] for c in update.message.reply_text.call_args_list)
+    assert "Alpha Project" in all_text
+    assert "Work was done." in all_text
+    assert "My Goal" in all_text
+    assert "Progress made." in all_text
+    mock_agent.generate_change_digest.assert_awaited_once_with(hours=24)
+
+
+@pytest.mark.asyncio
+async def test_cmd_changes_custom_hours(handler, brain_dir):
+    """/changes 48 passes hours=48 to generate_change_digest."""
+    from unittest.mock import AsyncMock as _AsyncMock
+    mock_agent = MagicMock()
+    mock_agent.generate_change_digest = _AsyncMock(return_value=[])
+
+    update, context = _make_update(12345, args=["48"])
+    with patch("goal_project_agent.GoalProjectAgent", return_value=mock_agent):
+        await handler.cmd_changes(update, context)
+
+    mock_agent.generate_change_digest.assert_awaited_once_with(hours=48)
+
+
+@pytest.mark.asyncio
+async def test_cmd_changes_rejects_out_of_range_hours(handler, brain_dir):
+    """/changes 999 is rejected before calling the agent."""
+    from unittest.mock import AsyncMock as _AsyncMock
+    mock_agent = MagicMock()
+    mock_agent.generate_change_digest = _AsyncMock(return_value=[])
+
+    update, context = _make_update(12345, args=["999"])
+    with patch("goal_project_agent.GoalProjectAgent", return_value=mock_agent):
+        await handler.cmd_changes(update, context)
+
+    text = update.message.reply_text.call_args[0][0]
+    assert "168" in text  # mentions the max
+    mock_agent.generate_change_digest.assert_not_awaited()

--- a/tests/unit/test_goal_project_agent.py
+++ b/tests/unit/test_goal_project_agent.py
@@ -590,3 +590,106 @@ def test_archive_superseded_action(tmp_path):
         fresh_fm = _parse_frontmatter(action_path.read_text())
         assert fresh_fm.get("status") == "superseded"
         assert "already exists" in fresh_fm.get("superseded_reason", "").lower()
+
+
+# ── generate_change_digest tests ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_generate_change_digest_empty_when_no_items(tmp_path):
+    """No active goals/projects → empty digest."""
+    memories_dir = tmp_path / "memories"
+    memories_dir.mkdir()
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"goal_agent": {"enabled": True}}))
+
+    with patch.object(gpa, "CONFIG_PATH", config_file), \
+         patch.object(gpa, "DEPLOY_DIR", tmp_path), \
+         patch.object(gpa, "MEMORIES_DIR", memories_dir):
+        agent = GoalProjectAgent(role="full", cache=_make_cache(memories_dir))
+        results = await agent.generate_change_digest(hours=24)
+        assert results == []
+
+
+@pytest.mark.asyncio
+async def test_generate_change_digest_excludes_stale_memories(tmp_path):
+    """Memories older than the cutoff are not included."""
+    memories_dir = tmp_path / "memories"
+    memories_dir.mkdir()
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"goal_agent": {"enabled": True}}))
+
+    # Create an active project with a matching tag
+    make_project_file(memories_dir, "Alpha Project", status="active", category="work")
+    # Create a memory with the matching tag but set its mtime to > 24h ago
+    mem_path = make_memory_file(
+        memories_dir, "email-alpha.md", "email_thread", "Alpha email", tags=["test"]
+    )
+    old_time = __import__("time").time() - 48 * 3600
+    import os
+    os.utime(str(mem_path), (old_time, old_time))
+
+    with patch.object(gpa, "CONFIG_PATH", config_file), \
+         patch.object(gpa, "DEPLOY_DIR", tmp_path), \
+         patch.object(gpa, "MEMORIES_DIR", memories_dir):
+        agent = GoalProjectAgent(role="full", cache=_make_cache(memories_dir))
+        results = await agent.generate_change_digest(hours=24)
+        # Memory is outside window → no results
+        assert results == []
+
+
+@pytest.mark.asyncio
+async def test_generate_change_digest_returns_entry_for_recent_activity(tmp_path):
+    """A project with a recently-modified related memory produces one digest entry."""
+    memories_dir = tmp_path / "memories"
+    memories_dir.mkdir()
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"goal_agent": {"enabled": True}}))
+
+    make_project_file(memories_dir, "Beta Project", status="active", category="work")
+    # Recent memory with matching tag
+    make_memory_file(
+        memories_dir, "email-beta.md", "email_thread", "Beta email", tags=["test"]
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = "Beta project had an email discussion."
+
+    with patch.object(gpa, "CONFIG_PATH", config_file), \
+         patch.object(gpa, "DEPLOY_DIR", tmp_path), \
+         patch.object(gpa, "MEMORIES_DIR", memories_dir), \
+         patch("litellm.acompletion", new=AsyncMock(return_value=mock_resp)):
+        agent = GoalProjectAgent(role="full", cache=_make_cache(memories_dir))
+        results = await agent.generate_change_digest(hours=24)
+
+    assert len(results) == 1
+    assert results[0]["title"] == "Beta Project"
+    assert results[0]["type"] == "project"
+    assert results[0]["memory_count"] == 1
+    assert "Beta project" in results[0]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_generate_change_digest_fallback_on_llm_error(tmp_path):
+    """LLM failure → fallback summary listing memory titles."""
+    memories_dir = tmp_path / "memories"
+    memories_dir.mkdir()
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"goal_agent": {"enabled": True}}))
+
+    make_project_file(memories_dir, "Gamma Project", status="active", category="work")
+    make_memory_file(
+        memories_dir, "email-gamma.md", "email_thread", "Gamma email", tags=["test"]
+    )
+
+    with patch.object(gpa, "CONFIG_PATH", config_file), \
+         patch.object(gpa, "DEPLOY_DIR", tmp_path), \
+         patch.object(gpa, "MEMORIES_DIR", memories_dir), \
+         patch("litellm.acompletion", new=AsyncMock(side_effect=Exception("LLM down"))):
+        agent = GoalProjectAgent(role="full", cache=_make_cache(memories_dir))
+        results = await agent.generate_change_digest(hours=24)
+
+    assert len(results) == 1
+    assert results[0]["memory_count"] == 1
+    # Fallback summary mentions the memory title or count
+    assert "1" in results[0]["summary"] or "Gamma" in results[0]["summary"]


### PR DESCRIPTION
## Summary

- Adds `/changes [hours]` Telegram command (default 24h, max 168h)
- Scans all active goals and projects, finds related memories updated within the window, and returns a concise LLM-generated paragraph per item with activity
- New `GoalProjectAgent.generate_change_digest(hours)` method reuses the existing `_find_related_memories()` recency filter + calls the cheap `summarize` LLM route once per active item
- Results sorted by activity count (most active first) and chunked to fit Telegram's 4096-char message limit
- Fallback on LLM failure: lists memory titles without calling LLM

## Test plan

- [x] `pytest` — 1393 passed, 0 failed
- [x] `test_generate_change_digest_empty_when_no_items` — no items → empty list
- [x] `test_generate_change_digest_excludes_stale_memories` — mtime > cutoff filtered out
- [x] `test_generate_change_digest_returns_entry_for_recent_activity` — recent memory → one result
- [x] `test_generate_change_digest_fallback_on_llm_error` — LLM failure → fallback summary
- [x] `test_cmd_changes_no_activity`, `test_cmd_changes_shows_digest`, `test_cmd_changes_custom_hours`, `test_cmd_changes_rejects_out_of_range_hours` — full command coverage
- [x] `test_changes_smoke` integration smoke test in `test_e2e_projects.py`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)