### PR TITLE
feat(installer): add openai provider + fix tier-detection idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `/project_note <N> <text>` — append a timestamped note to a project conversationally (#18).
 - `/project_due <N> <YYYY-MM-DD|none>` — update or clear a project's due date (#18).
 - `/changes [hours]` Telegram command: scans all active goals and projects, finds related memory files updated in the last N hours (default 24, max 168), and sends a concise LLM-generated activity digest per item — one paragraph per project/goal with recent activity. Implemented in `GoalProjectAgent.generate_change_digest()` (#74).
+- `install.sh` provider prompt now accepts `openai` as a fifth option alongside `gemini`, `claude`, `both`. Selecting `openai` prompts for `OPENAI_API_KEY`, writes it to the launchd plist and Keychain, and routes skill files to `openai/gpt-4o-mini` (summarisation) and `openai/gpt-4o` (quality/chat) via `scripts/apply_skill_provider.py` (#45). Note: `llm_routes.py` still hard-routes to Claude for non-SkillExecutor code paths (index builder, commitment tracker, etc.) — a follow-up will make those routes provider-aware.
 - `install.sh` now runs a Python smoke import (`import daemon` + `from chat_handler import TelegramChatHandler` on full role) after deploying source files and before reloading launchd. If the deployed artefact would crash at import time, the installer exits 1 and leaves the running daemon untouched.
 
 ### Fixed
@@ -37,10 +38,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `/usage` command now uses `_send_reply` instead of `reply_text` so long summaries are chunked and retried on transient network errors (#13).
 - `skill_executor`: `AuthenticationError` from LiteLLM now returns `None` immediately and logs an ERROR — the fallback model is never tried when the API key itself is bad (#59).
 - `skill_executor`: `PermissionDeniedError` (model-tier/entitlement 403) now falls back to the next configured model instead of hard-stopping, so skills with cross-provider fallbacks degrade gracefully when the preferred model is unavailable to the current key (#59).
+<<<<<<< HEAD
 - `chat_handler`: raised `HISTORY_WINDOW_TURNS` from 6 to 15 (30 messages) so long conversations retain context for 2.5× more turns without hitting the 200K token context limit (#70). The root cause of repeated context-loss complaints (#77, #65) is addressed by PR #80; this change provides headroom so a session can survive the tool-call iterations that filled the old window with `(I ran out of iterations…)` placeholders.
 - Chat tool-call loop: the `chat` skill prompt’s “Always attempt tool calls when appropriate” instruction caused the model to make unnecessary tool calls on questions already answered by `memory_context`, exhausting `max_iterations=5` and returning a “ran out of iterations” fallback visible to the user as “Too many tool calls” (#77). Rewrote the instruction to prefer context-first answers and call tools only when fresh data is genuinely required.
 - Chat lock starvation: added a 240 s `asyncio.wait_for` timeout around `executor.run_with_tools` in `handle_message`. A slow tool-call loop could hold the per-chat asyncio lock indefinitely, serialising all subsequent messages for that chat (#65, #77).
 - Mutation tracking: timeout warnings now show the result text of completed mutations (e.g. “Goal created: …”) rather than just the tool name, so users know what to verify before retrying. `deliver_pending_replies` added to `MUTATING_TOOLS` so it is tracked like other state-writing tools. In-flight mutations (in-progress when the timeout fired) are also reported separately, preventing blind retries that could resend already-delivered pending replies.
+=======
+- `scripts/apply_skill_provider.py`: fixed tier-detection idempotency — previously re-applying any provider to a skill already at `openai/gpt-4o` would misclassify it as cheap-tier and downgrade to `gpt-4o-mini`. Tier is now detected from model-ID patterns directly, so all cross-provider round-trips are idempotent (#45).
+>>>>>>> 63ee537 (feat(installer): add openai provider option + fix tier-detection idempotency (#45))
 
 ## [1.11.0] — 2026-04-28
 

--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,7 @@ EXISTING_ROLE=""
 EXISTING_PROVIDER=""
 EXISTING_GEMINI_KEY=""
 EXISTING_ANTHROPIC_KEY=""
+EXISTING_OPENAI_KEY=""
 EXISTING_TELEGRAM_TOKEN=""
 EXISTING_TELEGRAM_USER_ID=""
 EXISTING_ZOOM_ACCOUNT_ID=""
@@ -145,6 +146,7 @@ if [ -f "$PLIST_DEST" ]; then
     EXISTING_PROVIDER="$(_plist_env_val SECOND_BRAIN_PROVIDER)"
     EXISTING_GEMINI_KEY="$(_plist_env_val GEMINI_API_KEY)"
     EXISTING_ANTHROPIC_KEY="$(_plist_env_val ANTHROPIC_API_KEY)"
+    EXISTING_OPENAI_KEY="$(_plist_env_val OPENAI_API_KEY)"
     EXISTING_ZOOM_ACCOUNT_ID="$(_plist_env_val ZOOM_ACCOUNT_ID)"
     EXISTING_ZOOM_CLIENT_ID="$(_plist_env_val ZOOM_CLIENT_ID)"
     EXISTING_ZOOM_CLIENT_SECRET="$(_plist_env_val ZOOM_CLIENT_SECRET)"
@@ -195,6 +197,7 @@ printf "  Which LLM providers do you want this daemon to use?\n"
 printf "    gemini  Gemini only (cheap, fast; no Anthropic key needed)\n"
 printf "    claude  Claude only (higher quality; no Gemini key needed)\n"
 printf "    both    Prefer Claude, fall back to Gemini on errors (recommended)\n"
+printf "    openai  OpenAI only (GPT-4o for quality, GPT-4o-mini for summarisation)\n"
 echo ""
 DEFAULT_PROVIDER="${EXISTING_PROVIDER:-both}"
 if [ "$NONINTERACTIVE" = "1" ]; then
@@ -203,8 +206,8 @@ else
     read -r -p "  Provider [$DEFAULT_PROVIDER]: " PROVIDER
     PROVIDER="${PROVIDER:-$DEFAULT_PROVIDER}"
 fi
-[[ "$PROVIDER" == "gemini" || "$PROVIDER" == "claude" || "$PROVIDER" == "both" ]] \
-    || die "Provider must be 'gemini', 'claude', or 'both'."
+[[ "$PROVIDER" == "gemini" || "$PROVIDER" == "claude" || "$PROVIDER" == "both" || "$PROVIDER" == "openai" ]] \
+    || die "Provider must be 'gemini', 'claude', 'both', or 'openai'."
 ok "Provider: $PROVIDER"
 
 # ── 4. API keys ───────────────────────────────────────────────────────────────
@@ -254,6 +257,29 @@ if [ "$PROVIDER" != "gemini" ]; then
             ok "Anthropic API key (kept existing)"
         elif [ -z "$ANTHROPIC_KEY" ]; then
             die "Anthropic API key is required for provider '$PROVIDER'."
+        fi
+    fi
+fi
+
+# ── 4a. OpenAI API key (openai provider only) ────────────────────────────────
+OPENAI_KEY=""
+if [ "$PROVIDER" = "openai" ]; then
+    if [ -n "${OPENAI_API_KEY:-}" ]; then
+        ok "OPENAI_API_KEY (from environment)"
+        OPENAI_KEY="$OPENAI_API_KEY"
+    elif [ -n "$EXISTING_OPENAI_KEY" ]; then
+        ok "OpenAI API key (from existing config)"
+        OPENAI_KEY="$EXISTING_OPENAI_KEY"
+    elif [ "$NONINTERACTIVE" = "1" ]; then
+        die "NONINTERACTIVE mode requires existing OpenAI API key or OPENAI_API_KEY env var"
+    else
+        echo "  Get one at: https://platform.openai.com/api-keys"
+        read -r -p "  OpenAI API key: " OPENAI_KEY
+        if [ -z "$OPENAI_KEY" ] && [ -n "$EXISTING_OPENAI_KEY" ]; then
+            OPENAI_KEY="$EXISTING_OPENAI_KEY"
+            ok "OpenAI API key (kept existing)"
+        elif [ -z "$OPENAI_KEY" ]; then
+            die "OpenAI API key is required for provider 'openai'."
         fi
     fi
 fi
@@ -443,6 +469,7 @@ _store_in_keychain() {
 
 [ -n "$GEMINI_KEY" ] && _store_in_keychain "gemini_api_key" "$GEMINI_KEY"
 [ -n "$ANTHROPIC_KEY" ] && _store_in_keychain "anthropic_api_key" "$ANTHROPIC_KEY"
+[ -n "$OPENAI_KEY" ] && _store_in_keychain "openai_api_key" "$OPENAI_KEY"
 [ -n "$ZOOM_ACCOUNT_ID" ] && _store_in_keychain "zoom_account_id" "$ZOOM_ACCOUNT_ID"
 [ -n "$ZOOM_CLIENT_ID" ] && _store_in_keychain "zoom_client_id" "$ZOOM_CLIENT_ID"
 [ -n "$ZOOM_CLIENT_SECRET" ] && _store_in_keychain "zoom_client_secret" "$ZOOM_CLIENT_SECRET"
@@ -761,6 +788,8 @@ cat > "$PLIST_TMP" << PLIST_EOF
     <string>${GEMINI_KEY}</string>
     <key>ANTHROPIC_API_KEY</key>
     <string>${ANTHROPIC_KEY}</string>
+    <key>OPENAI_API_KEY</key>
+    <string>${OPENAI_KEY}</string>
     <key>ZOOM_ACCOUNT_ID</key>
     <string>${ZOOM_ACCOUNT_ID}</string>
     <key>ZOOM_CLIENT_ID</key>

--- a/scripts/apply_skill_provider.py
+++ b/scripts/apply_skill_provider.py
@@ -3,7 +3,7 @@
 Apply LLM provider preference to skill files.
 
 Invoked by install.sh at deploy time as:
-    PROVIDER=<gemini|claude|both> python3 scripts/apply_skill_provider.py <skills_dir>
+    PROVIDER=<gemini|claude|both|openai> python3 scripts/apply_skill_provider.py <skills_dir>
 
 Rewrites preferred_model and fallback_model in skill frontmatter according to
 the chosen provider strategy.
@@ -15,18 +15,43 @@ from pathlib import Path
 
 import yaml
 
+# Canonical "quality tier" model for each provider (sonnet/GPT-4o-class).
+_QUALITY_MODEL = {
+    "gemini": "gemini/gemini-2.0-flash",
+    "claude": "claude-sonnet-4-6",
+    "both":   "claude-sonnet-4-6",
+    "openai": "openai/gpt-4o",
+}
+
+# Canonical "cheap tier" model for each provider (high-volume summarisation).
+_CHEAP_MODEL = {
+    "gemini": "gemini/gemini-2.0-flash",
+    "claude": "claude-haiku-4-5-20251001",
+    "both":   "claude-haiku-4-5-20251001",
+    "openai": "openai/gpt-4o-mini",
+}
+
+_VALID_PROVIDERS = frozenset(_QUALITY_MODEL)
+
+
+def _is_quality_tier(model_id: str) -> bool:
+    """Return True if model_id is a quality (sonnet/GPT-4o-class) model."""
+    m = model_id.lower()
+    if "sonnet" in m:
+        return True
+    # gpt-4o quality tier, but NOT gpt-4o-mini
+    if "gpt-4o" in m and "mini" not in m:
+        return True
+    # Gemini Pro / 1.5-pro variants
+    if "gemini" in m and ("pro" in m or "1.5" in m or "ultra" in m):
+        return True
+    return False
+
 
 def apply_provider(skills_dir: Path, provider: str):
-    """
-    Walk all .md files in skills_dir and rewrite frontmatter model fields
-    according to the provider strategy.
-
-    Args:
-        skills_dir: Path to directory containing skill .md files
-        provider: One of "gemini", "claude", or "both"
-    """
-    if provider not in ("gemini", "claude", "both"):
-        print(f"[error] Invalid provider: {provider}")
+    """Walk all .md files in skills_dir and rewrite frontmatter model fields."""
+    if provider not in _VALID_PROVIDERS:
+        print(f"[error] Invalid provider: {provider}. Valid: {sorted(_VALID_PROVIDERS)}")
         sys.exit(1)
 
     for skill_file in sorted(skills_dir.glob("*.md")):
@@ -37,7 +62,6 @@ def _apply_to_file(skill_file: Path, provider: str):
     """Apply provider strategy to a single skill file."""
     content = skill_file.read_text()
 
-    # Parse frontmatter
     if not content.startswith("---\n"):
         print(f"[warn] {skill_file.name}  (no frontmatter)")
         return
@@ -58,24 +82,21 @@ def _apply_to_file(skill_file: Path, provider: str):
         return
 
     current_preferred = meta["preferred_model"]
-    is_sonnet = "sonnet" in current_preferred.lower()
+    quality = _is_quality_tier(current_preferred)
 
-    # Determine new values
+    # Determine new values based on provider and current skill tier
     if provider == "gemini":
         new_preferred = "gemini/gemini-2.0-flash"
         new_fallback = None
     elif provider == "claude":
-        if is_sonnet:
-            new_preferred = current_preferred  # keep existing sonnet model
-        else:
-            new_preferred = "claude-haiku-4-5-20251001"
+        new_preferred = _QUALITY_MODEL["claude"] if quality else _CHEAP_MODEL["claude"]
+        new_fallback = None
+    elif provider == "openai":
+        new_preferred = _QUALITY_MODEL["openai"] if quality else _CHEAP_MODEL["openai"]
         new_fallback = None
     else:  # both
-        if is_sonnet:
-            new_preferred = current_preferred  # keep existing sonnet model
-        else:
-            new_preferred = "claude-haiku-4-5-20251001"
-        new_fallback = "claude-haiku-4-5-20251001"
+        new_preferred = _QUALITY_MODEL["both"] if quality else _CHEAP_MODEL["both"]
+        new_fallback = _CHEAP_MODEL["both"]
 
     # Check if changes are needed
     current_fallback = meta.get("fallback_model")
@@ -111,7 +132,7 @@ def _apply_to_file(skill_file: Path, provider: str):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: PROVIDER=<gemini|claude|both> python3 apply_skill_provider.py <skills_dir>")
+        print("Usage: PROVIDER=<gemini|claude|both|openai> python3 apply_skill_provider.py <skills_dir>")
         sys.exit(1)
 
     provider = os.environ.get("PROVIDER")

--- a/tests/unit/test_apply_skill_provider.py
+++ b/tests/unit/test_apply_skill_provider.py
@@ -54,6 +54,30 @@ success_rate: null
 Docs instructions.
 """
 
+OPENAI_MINI_SKILL = """\
+---
+name: summarize-webpage
+version: 1
+preferred_model: openai/gpt-4o-mini
+---
+
+## Instructions
+
+Do stuff.
+"""
+
+OPENAI_QUALITY_SKILL = """\
+---
+name: chat
+version: 1
+preferred_model: openai/gpt-4o
+---
+
+## Instructions
+
+Chat instructions.
+"""
+
 
 @pytest.fixture
 def skills_dir(tmp_path):
@@ -152,3 +176,61 @@ def test_gemini_skill_on_gemini_provider_is_noop(skills_dir):
     fm = get_frontmatter(read_skill(skills_dir, "summarize-docs"))
     assert fm["preferred_model"] == "gemini/gemini-2.0-flash"
     assert "fallback_model" not in fm
+
+
+# ── OpenAI provider tests ──────────────────────────────────────────────────────
+
+def test_openai_provider_haiku_skill_maps_to_mini(skills_dir):
+    write_skill(skills_dir, "summarize-webpage", HAIKU_SKILL)
+    asp.apply_provider(skills_dir, "openai")
+    fm = get_frontmatter(read_skill(skills_dir, "summarize-webpage"))
+    assert fm["preferred_model"] == "openai/gpt-4o-mini"
+    assert "fallback_model" not in fm
+
+
+def test_openai_provider_sonnet_skill_maps_to_gpt4o(skills_dir):
+    write_skill(skills_dir, "chat", SONNET_SKILL)
+    asp.apply_provider(skills_dir, "openai")
+    fm = get_frontmatter(read_skill(skills_dir, "chat"))
+    assert fm["preferred_model"] == "openai/gpt-4o"
+    assert "fallback_model" not in fm
+
+
+def test_openai_provider_preserves_execution_history(skills_dir):
+    write_skill(skills_dir, "summarize-webpage", HAIKU_SKILL)
+    asp.apply_provider(skills_dir, "openai")
+    content = read_skill(skills_dir, "summarize-webpage")
+    assert "2026-04-12 | test-slug | claude-haiku | 0.90" in content
+
+
+def test_openai_mini_skill_idempotent_on_openai_provider(skills_dir):
+    """gpt-4o-mini skill re-applied with openai provider: no change."""
+    write_skill(skills_dir, "summarize-webpage", OPENAI_MINI_SKILL)
+    asp.apply_provider(skills_dir, "openai")
+    fm = get_frontmatter(read_skill(skills_dir, "summarize-webpage"))
+    assert fm["preferred_model"] == "openai/gpt-4o-mini"
+
+
+def test_openai_quality_skill_idempotent_on_openai_provider(skills_dir):
+    """gpt-4o skill re-applied with openai provider: stays gpt-4o (not demoted to mini)."""
+    write_skill(skills_dir, "chat", OPENAI_QUALITY_SKILL)
+    asp.apply_provider(skills_dir, "openai")
+    fm = get_frontmatter(read_skill(skills_dir, "chat"))
+    assert fm["preferred_model"] == "openai/gpt-4o"
+
+
+def test_cross_provider_round_trip_openai_to_claude(skills_dir):
+    """Switch from openai to claude: gpt-4o-mini (cheap) → haiku, gpt-4o (quality) → sonnet."""
+    write_skill(skills_dir, "summarize-webpage", OPENAI_MINI_SKILL)
+    write_skill(skills_dir, "chat", OPENAI_QUALITY_SKILL)
+    asp.apply_provider(skills_dir, "claude")
+    cheap_fm = get_frontmatter(read_skill(skills_dir, "summarize-webpage"))
+    quality_fm = get_frontmatter(read_skill(skills_dir, "chat"))
+    assert cheap_fm["preferred_model"] == "claude-haiku-4-5-20251001"
+    assert "sonnet" in quality_fm["preferred_model"]
+
+
+def test_invalid_provider_exits(skills_dir):
+    import pytest
+    with pytest.raises(SystemExit):
+        asp.apply_provider(skills_dir, "unknown-provider")


### PR DESCRIPTION
## Summary

- `install.sh` now accepts `openai` as a provider option alongside `gemini`, `claude`, and `both`. Selecting `openai` prompts for `OPENAI_API_KEY`, stores it in Keychain and the launchd plist.
- `scripts/apply_skill_provider.py` routes cheap/summarise skills to `openai/gpt-4o-mini` and quality/chat skills to `openai/gpt-4o`.
- Fixed a latent idempotency bug in `apply_skill_provider.py`: tier was detected by checking for the word "sonnet" in the model name. A skill already at `openai/gpt-4o` would be misclassified as cheap-tier on a second apply and downgraded to `gpt-4o-mini`. Replaced with `_is_quality_tier()` that recognises sonnet, gpt-4o (non-mini), and gemini-pro variants from any provider.
- 7 new tests covering openai routing, idempotency, and cross-provider round-trips.

**Known limitation:** `llm_routes.py` still hard-routes to Claude for non-SkillExecutor code paths (index builder, commitment tracker, etc.). A follow-up will make those routes provider-aware.

## Test plan

- [x] `pytest tests/unit/test_apply_skill_provider.py` — 16 tests, all pass
- [x] Full suite: `pytest tests/` — 1400 passed

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)