### PR TITLE
feat(usage): track LLM token usage per model + /usage command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `/changes [hours]` Telegram command: scans all active goals and projects, finds related memory files updated in the last N hours (default 24, max 168), and sends a concise LLM-generated activity digest per item — one paragraph per project/goal with recent activity. Implemented in `GoalProjectAgent.generate_change_digest()` (#74).
 
 ### Fixed
+- `usage_tracker.record_usage`: read-modify-write on the state JSON is now protected by a module-level `threading.Lock`, preventing lost increments when multiple async loops call it concurrently (#13).
+- `skill_optimizer`: all four `acompletion` call sites now record token usage via `record_usage`, so `/usage` totals include judge and optimizer traffic (#13).
+- `/usage` command now uses `_send_reply` instead of `reply_text` so long summaries are chunked and retried on transient network errors (#13).
 - `skill_executor`: `AuthenticationError` from LiteLLM now returns `None` immediately and logs an ERROR — the fallback model is never tried when the API key itself is bad (#59).
 - `skill_executor`: `PermissionDeniedError` (model-tier/entitlement 403) now falls back to the next configured model instead of hard-stopping, so skills with cross-provider fallbacks degrade gracefully when the preferred model is unavailable to the current key (#59).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `usage_tracker`: records prompt/completion token counts per model per day from every LiteLLM call in `skill_executor`. State stored in `~/secondbrain/usage-tracker-state.json` with 30-day retention (#13).
+- `/usage [days]` Telegram command: shows token usage totals per model for the last N days (default 7). `/usage daily` shows a per-day rolling total. Works across all models routed through LiteLLM (#13).
 - `/goal_note <N> <text>` — append a timestamped note to a goal conversationally (#18).
 - `/goal_due <N> <YYYY-MM-DD|none>` — update or clear a goal's due date (#18).
 - `/project_note <N> <text>` — append a timestamped note to a project conversationally (#18).

--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ Muted state persists across daemon restarts. `/briefing` works even when muted �
 |---------|--------|
 | **Meta** | |
 | `/help`, `/commands` | Show all available commands grouped by category |
+| `/usage [days]` | Show LLM token usage per model for the last N days (default 7). Tracks prompt + completion tokens from all LiteLLM calls. |
+| `/usage daily` | Per-day rolling totals for the last 7 days. |
 | **Skill management** | |
 | `/skill-health` | Utility scores and trend arrows for every skill. Sorted worst-first; `▲` improving, `▼` declining, `◆` stable, `—` insufficient data. `⚠` = below underperformance threshold or declining. |
 | `/skill-drafts` | List auto-drafted skill files awaiting approval (only populated when `/skill-approval on`). |
@@ -622,6 +624,7 @@ Runtime state (local per machine):
 ├── commitment-corrections.jsonl    # /wrong and /missed feedback log
 ├── commitment-accuracy.json        # extraction precision stats per source type
 ├── rejected-candidates.json        # rejected candidate sources to prevent re-proposal
+├── usage-tracker-state.json        # daily token usage per model (30-day rolling window)
 └── notification-state.json         # chat_id, mute state, sent alerts
 
 iCloud (shared across all machines):

--- a/calendar_scanner.py
+++ b/calendar_scanner.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from utils import load_config
 
 log = logging.getLogger("calendar-scanner")
@@ -1116,6 +1117,8 @@ Return JSON only:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
 
             # Strip ```json fences if the model wrapped its output (Haiku does

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -4152,7 +4152,7 @@ class TelegramChatHandler:
                     )
                     return
             text = render_usage(days)
-        await update.message.reply_text(text)
+        await self._send_reply(update, text)
 
     async def cmd_rebuild_cache(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Rebuild the memory cache from scratch."""

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -130,6 +130,7 @@ class TelegramChatHandler:
         self.app.add_handler(CommandHandler("help", self.cmd_help))
         self.app.add_handler(CommandHandler("commands", self.cmd_help))
         self.app.add_handler(CommandHandler("version", self.cmd_version))
+        self.app.add_handler(CommandHandler("usage", self.cmd_usage))
         self.app.add_handler(CommandHandler("settings", self.cmd_settings))
         self.app.add_handler(CommandHandler("reset", self.cmd_reset))
         self.app.add_handler(CommandHandler("deliver", self.cmd_deliver))
@@ -4131,6 +4132,27 @@ class TelegramChatHandler:
         version_file = Path(__file__).parent / "VERSION"
         version = version_file.read_text().strip() if version_file.exists() else "unknown"
         await update.message.reply_text(f"second-brain v{version}")
+
+    async def cmd_usage(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Show LLM token usage summary. /usage [days] or /usage daily."""
+        if not self._check_auth(update):
+            return
+        from usage_tracker import render_usage, render_daily_breakdown
+        args = context.args or []
+        if args and args[0] == "daily":
+            text = render_daily_breakdown()
+        else:
+            days = 7
+            if args:
+                try:
+                    days = max(1, min(int(args[0]), 90))
+                except ValueError:
+                    await update.message.reply_text(
+                        "Usage: /usage [days] or /usage daily"
+                    )
+                    return
+            text = render_usage(days)
+        await update.message.reply_text(text)
 
     async def cmd_rebuild_cache(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Rebuild the memory cache from scratch."""

--- a/code_scanner.py
+++ b/code_scanner.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from skill_executor import SkillExecutor
 from utils import load_config
 
@@ -637,6 +638,8 @@ class CodeScanner:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             summary = ""
             tags = []

--- a/command_core.py
+++ b/command_core.py
@@ -156,6 +156,7 @@ COMMAND_REGISTRY: dict[str, list[tuple[str, str]]] = {
         ("deliver",  "Send queued replies that couldn't be delivered due to network issues"),
         ("discard",  "Drop queued replies that couldn't be delivered due to network issues"),
         ("version",  "Show the running daemon version"),
+        ("usage",    "Show LLM token usage. /usage [days] (default 7). /usage daily for per-day breakdown"),
     ],
     "System": [
         ("backfill",       "Reprocess historical data: /backfill <type> [days] [host]. Types: readings, email, zoom, calendar, slack, projects"),

--- a/commitment_tracker.py
+++ b/commitment_tracker.py
@@ -11,6 +11,7 @@ from typing import Optional
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from utils import load_config
 
 log = logging.getLogger("commitment-tracker")
@@ -271,6 +272,8 @@ class CommitmentTracker:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             text = re.sub(r'^```(?:json)?\n?', '', text)
             text = re.sub(r'\n?```$', '', text)

--- a/email_scanner.py
+++ b/email_scanner.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from utils import load_config
 
 log = logging.getLogger("email-scanner")
@@ -706,6 +707,8 @@ class EmailScanner:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             summary = ""
             tags = []

--- a/goal_project_agent.py
+++ b/goal_project_agent.py
@@ -18,6 +18,7 @@ from typing import Optional
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from utils import load_config
 
 log = logging.getLogger("goal-agent")
@@ -315,6 +316,8 @@ class GoalProjectAgent:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("chat"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             # Strip markdown fences
             text = re.sub(r'^```(?:json)?\n?', '', text)
@@ -814,6 +817,8 @@ class GoalProjectAgent:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=20,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             return resp.choices[0].message.content.strip()
         except Exception as e:
             log.warning("Digest summary LLM call failed for %s: %s", title, e)

--- a/index_builder.py
+++ b/index_builder.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from litellm import acompletion
 from llm_routes import resolve
+from usage_tracker import record_usage
 from utils import load_config
 from memory_cache import MemoryCache
 
@@ -77,6 +78,8 @@ class IndexBuilder:
                 ],
                 max_tokens=700
             )
+            if hasattr(response, "usage") and response.usage:
+                record_usage(resolve("summarize"), response.usage.prompt_tokens or 0, response.usage.completion_tokens or 0)
             synthesis = response.choices[0].message.content
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
             content = f"*Last updated: {timestamp} — {n} memories indexed*\n\n{synthesis}\n"

--- a/project_inference_scanner.py
+++ b/project_inference_scanner.py
@@ -19,6 +19,7 @@ from typing import Optional
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from memory_cache import MemoryCache
 
 log = logging.getLogger("project-inference")
@@ -384,6 +385,8 @@ class ProjectInferenceScanner:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             # Strip markdown fences if present
             text = re.sub(r'^```(?:json)?\n?', '', text)

--- a/report_scheduler.py
+++ b/report_scheduler.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 
 if TYPE_CHECKING:
     from telegram import Bot
@@ -345,6 +346,8 @@ class AnalysisGenerator:
                 messages=messages,
                 max_tokens=500
             )
+            if hasattr(response, "usage") and response.usage:
+                record_usage(resolve(model_route), response.usage.prompt_tokens or 0, response.usage.completion_tokens or 0)
             return response.choices[0].message.content.strip()
         except Exception as e:
             log.error(f"Analysis generation failed: {e}")

--- a/skill_creator.py
+++ b/skill_creator.py
@@ -22,6 +22,7 @@ import yaml
 from litellm import acompletion
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 
 if TYPE_CHECKING:
     from skill_optimizer import SkillOptimizer
@@ -213,6 +214,8 @@ Output ONLY the complete skill markdown file. No preamble, no explanation, no co
                     messages=[{"role": "user", "content": prompt}],
                     max_tokens=1500
                 )
+                if hasattr(response, "usage") and response.usage:
+                    record_usage(resolve(self.model_route), response.usage.prompt_tokens or 0, response.usage.completion_tokens or 0)
                 result = response.choices[0].message.content
 
                 # Strip code fences if present

--- a/skill_executor.py
+++ b/skill_executor.py
@@ -19,6 +19,7 @@ from litellm.exceptions import (
     PermissionDeniedError as LiteLLMPermissionError,
 )
 from llm_routes import resolve
+from usage_tracker import record_usage
 from utils import read_text_with_retry, read_bytes_with_retry
 
 # Transient failures — retry on the fallback model.
@@ -161,6 +162,10 @@ class SkillExecutor:
                 max_tokens = self._skill["meta"].get("max_tokens", 1000)
                 response = await acompletion(model=resolve(model), messages=messages, max_tokens=max_tokens, timeout=timeout_s)
                 result = response.choices[0].message.content
+                if hasattr(response, "usage") and response.usage:
+                    record_usage(resolve(model),
+                                 response.usage.prompt_tokens or 0,
+                                 response.usage.completion_tokens or 0)
                 await self._log_execution(inputs, resolve(model), score=score)
                 if model != preferred:
                     log.warning(f"{self.skill_name} succeeded on fallback {resolve(model)} "
@@ -311,6 +316,10 @@ class SkillExecutor:
                         max_tokens=2000,
                         timeout=timeout_s,
                     )
+                    if hasattr(response, "usage") and response.usage:
+                        record_usage(resolve(model),
+                                     response.usage.prompt_tokens or 0,
+                                     response.usage.completion_tokens or 0)
                     msg = response.choices[0].message
                     tool_calls = getattr(msg, "tool_calls", None) or []
 

--- a/skill_optimizer.py
+++ b/skill_optimizer.py
@@ -13,6 +13,7 @@ from typing import Optional
 from litellm import acompletion
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from utils import load_config
 
 log = logging.getLogger("skill-optimizer")
@@ -544,6 +545,8 @@ Respond with JSON only:
             ),
             timeout=30
         )
+        if hasattr(response, "usage") and response.usage:
+            record_usage(resolve(self.judge_model), response.usage.prompt_tokens or 0, response.usage.completion_tokens or 0)
 
         result_text = response.choices[0].message.content.strip()
 
@@ -935,6 +938,8 @@ Be specific. Cite evidence from the execution examples. Avoid generic observatio
                 ),
                 timeout=60
             )
+            if hasattr(response, "usage") and response.usage:
+                record_usage(resolve("optimizer"), response.usage.prompt_tokens or 0, response.usage.completion_tokens or 0)
 
             result_text = response.choices[0].message.content.strip()
 
@@ -1042,6 +1047,8 @@ Please rewrite the skill file following the meta-skill instructions."""
                 ),
                 timeout=60
             )
+            if hasattr(response, "usage") and response.usage:
+                record_usage(resolve("optimizer"), response.usage.prompt_tokens or 0, response.usage.completion_tokens or 0)
 
             new_skill_text = response.choices[0].message.content.strip()
 
@@ -1322,6 +1329,8 @@ Respond with JSON only: {{"score": 1, "reasoning": "one sentence"}}"""
                 ),
                 timeout=30
             )
+            if hasattr(response, "usage") and response.usage:
+                record_usage(resolve(self.judge_model), response.usage.prompt_tokens or 0, response.usage.completion_tokens or 0)
             text = response.choices[0].message.content.strip()
             data = json.loads(text)
             score = int(data.get("score", 3))

--- a/slack_scanner.py
+++ b/slack_scanner.py
@@ -12,6 +12,7 @@ from typing import Optional
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from secrets import get_secret_or_env
 from slack_client import SlackClient
 from utils import load_config
@@ -208,6 +209,8 @@ class SlackScanner:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             text = re.sub(r'^```(?:json)?\n?', '', text)
             text = re.sub(r'\n?```$', '', text)

--- a/synthesis_scanner.py
+++ b/synthesis_scanner.py
@@ -12,6 +12,7 @@ import yaml
 from litellm import acompletion
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from memory_writer import MemoryWriter
 
 log = logging.getLogger("synthesis-scanner")
@@ -211,6 +212,8 @@ async def _synthesize(cluster_paths: list[Path], config: dict) -> Optional[str]:
             messages=[{"role": "user", "content": prompt}],
             timeout=30,
         )
+        if hasattr(resp, "usage") and resp.usage:
+            record_usage(resolve("chat"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
         return resp.choices[0].message.content.strip()
     except Exception:
         log.exception("LLM call failed for synthesis generation")

--- a/tests/integration/test_e2e_meta_system.py
+++ b/tests/integration/test_e2e_meta_system.py
@@ -46,6 +46,14 @@ async def test_version_smoke(handler, mk_update):
     update.message.reply_text.assert_called()
 
 
+async def test_usage_smoke(handler, mk_update, tmp_path, monkeypatch):
+    import usage_tracker as ut
+    monkeypatch.setattr(ut, "USAGE_STATE_FILE", tmp_path / "usage.json")
+    update, ctx = mk_update("/usage")
+    await handler.cmd_usage(update, ctx)
+    update.message.reply_text.assert_called()
+
+
 async def test_backfill_smoke(handler, mk_update):
     update, ctx = mk_update("/backfill", args=["readings", "7"])
     await handler.cmd_backfill(update, ctx)

--- a/tests/integration/test_e2e_meta_system.py
+++ b/tests/integration/test_e2e_meta_system.py
@@ -46,9 +46,10 @@ async def test_version_smoke(handler, mk_update):
     update.message.reply_text.assert_called()
 
 
-async def test_usage_smoke(handler, mk_update, tmp_path, monkeypatch):
+async def test_usage_smoke(handler, mk_update, monkeypatch):
     import usage_tracker as ut
-    monkeypatch.setattr(ut, "USAGE_STATE_FILE", tmp_path / "usage.json")
+    monkeypatch.setattr(ut, "render_usage", lambda days=7: f"No usage data ({days}d)")
+    monkeypatch.setattr(ut, "render_daily_breakdown", lambda: "No daily data")
     update, ctx = mk_update("/usage")
     await handler.cmd_usage(update, ctx)
     update.message.reply_text.assert_called()

--- a/tests/unit/test_usage_tracker.py
+++ b/tests/unit/test_usage_tracker.py
@@ -1,0 +1,150 @@
+"""Unit tests for usage_tracker.py."""
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+import usage_tracker as ut
+from usage_tracker import record_usage, render_usage, render_daily_breakdown
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _state(tmp_path: Path) -> dict:
+    sf = tmp_path / "usage-tracker-state.json"
+    return json.loads(sf.read_text()) if sf.exists() else {}
+
+
+# ── record_usage ──────────────────────────────────────────────────────────────
+
+def test_record_usage_creates_state_file(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    record_usage("claude-haiku", 100, 50, state_file=sf)
+    assert sf.exists()
+
+
+def test_record_usage_accumulates_tokens(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    record_usage("claude-haiku", 100, 50, state_file=sf)
+    record_usage("claude-haiku", 200, 80, state_file=sf)
+    state = _state(tmp_path)
+    today = datetime.now().strftime("%Y-%m-%d")
+    entry = state[today]["claude-haiku"]
+    assert entry["prompt_tokens"] == 300
+    assert entry["completion_tokens"] == 130
+    assert entry["calls"] == 2
+
+
+def test_record_usage_multiple_models(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    record_usage("model-a", 100, 20, state_file=sf)
+    record_usage("model-b", 50, 10, state_file=sf)
+    state = _state(tmp_path)
+    today = datetime.now().strftime("%Y-%m-%d")
+    assert "model-a" in state[today]
+    assert "model-b" in state[today]
+
+
+def test_record_usage_skips_zero_tokens(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    record_usage("model-a", 0, 0, state_file=sf)
+    assert not sf.exists()
+
+
+def test_record_usage_noop_on_exception(tmp_path, monkeypatch):
+    """record_usage must not raise even if the state file is unwriteable."""
+    sf = tmp_path / "usage-tracker-state.json"
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(ut, "_save_state", boom)
+    # Should not raise
+    record_usage("model-a", 10, 5, state_file=sf)
+
+
+def test_record_usage_atomic_write(tmp_path):
+    """State file is written atomically — no .tmp file left behind."""
+    sf = tmp_path / "usage-tracker-state.json"
+    record_usage("model-a", 10, 5, state_file=sf)
+    tmp_file = sf.with_suffix(".tmp")
+    assert not tmp_file.exists()
+
+
+# ── render_usage ──────────────────────────────────────────────────────────────
+
+def test_render_usage_no_data(tmp_path):
+    sf = tmp_path / "empty.json"
+    result = render_usage(days=7, state_file=sf)
+    assert "No usage data" in result
+
+
+def test_render_usage_shows_totals(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    record_usage("claude-haiku", 1000, 200, state_file=sf)
+    result = render_usage(days=7, state_file=sf)
+    assert "claude-haiku" in result
+    assert "1,000" in result
+    assert "200" in result
+
+
+def test_render_usage_respects_days_window(tmp_path, monkeypatch):
+    """Entries older than 'days' are excluded."""
+    sf = tmp_path / "usage-tracker-state.json"
+    old_date = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%d")
+    state = {old_date: {"old-model": {"prompt_tokens": 9999, "completion_tokens": 1, "calls": 1}}}
+    sf.write_text(json.dumps(state))
+    result = render_usage(days=7, state_file=sf)
+    assert "old-model" not in result
+
+
+def test_render_usage_includes_recent_data(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    recent = datetime.now().strftime("%Y-%m-%d")
+    state = {recent: {"new-model": {"prompt_tokens": 500, "completion_tokens": 100, "calls": 3}}}
+    sf.write_text(json.dumps(state))
+    result = render_usage(days=7, state_file=sf)
+    assert "new-model" in result
+    assert "500" in result
+
+
+def test_render_usage_shows_grand_total(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    record_usage("model-a", 1000, 200, state_file=sf)
+    record_usage("model-b", 500, 100, state_file=sf)
+    result = render_usage(days=7, state_file=sf)
+    assert "Total:" in result
+    assert "1,800" in result  # 1000+200+500+100
+
+
+# ── render_daily_breakdown ────────────────────────────────────────────────────
+
+def test_render_daily_breakdown_no_data(tmp_path):
+    sf = tmp_path / "empty.json"
+    result = render_daily_breakdown(state_file=sf)
+    assert "No daily usage data" in result
+
+
+def test_render_daily_breakdown_shows_dates(tmp_path):
+    sf = tmp_path / "usage-tracker-state.json"
+    today = datetime.now().strftime("%Y-%m-%d")
+    state = {today: {"model-a": {"prompt_tokens": 300, "completion_tokens": 100, "calls": 2}}}
+    sf.write_text(json.dumps(state))
+    result = render_daily_breakdown(state_file=sf)
+    assert today in result
+    assert "400" in result  # 300 + 100
+
+
+# ── pruning ────────────────────────────────────────────────────────────────────
+
+def test_old_entries_pruned_on_record(tmp_path):
+    """Entries beyond RETENTION_DAYS are removed when a new record is written."""
+    sf = tmp_path / "usage-tracker-state.json"
+    old_date = (datetime.now() - timedelta(days=35)).strftime("%Y-%m-%d")
+    state = {old_date: {"old-model": {"prompt_tokens": 1, "completion_tokens": 1, "calls": 1}}}
+    sf.write_text(json.dumps(state))
+    record_usage("new-model", 10, 5, state_file=sf)
+    final = json.loads(sf.read_text())
+    assert old_date not in final

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -17,10 +17,13 @@ Usage recording is best-effort — failures are logged but never raised.
 import json
 import logging
 import os
+import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 
 log = logging.getLogger("usage-tracker")
+
+_usage_lock = threading.Lock()
 
 DEPLOY_DIR = Path(os.environ.get("SECOND_BRAIN_DIR", str(Path.home() / "secondbrain")))
 USAGE_STATE_FILE = DEPLOY_DIR / "usage-tracker-state.json"
@@ -60,15 +63,16 @@ def record_usage(
     if not prompt_tokens and not completion_tokens:
         return
     try:
-        state = _load_state(state_file)
-        today = datetime.now().strftime("%Y-%m-%d")
-        day = state.setdefault(today, {})
-        entry = day.setdefault(model, {"prompt_tokens": 0, "completion_tokens": 0, "calls": 0})
-        entry["prompt_tokens"] += prompt_tokens
-        entry["completion_tokens"] += completion_tokens
-        entry["calls"] += 1
-        state = _prune_old_days(state, RETENTION_DAYS)
-        _save_state(state, state_file)
+        with _usage_lock:
+            state = _load_state(state_file)
+            today = datetime.now().strftime("%Y-%m-%d")
+            day = state.setdefault(today, {})
+            entry = day.setdefault(model, {"prompt_tokens": 0, "completion_tokens": 0, "calls": 0})
+            entry["prompt_tokens"] += prompt_tokens
+            entry["completion_tokens"] += completion_tokens
+            entry["calls"] += 1
+            state = _prune_old_days(state, RETENTION_DAYS)
+            _save_state(state, state_file)
     except Exception as e:
         log.debug("record_usage failed (non-fatal): %s", e)
 

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -1,0 +1,128 @@
+"""Track LLM token usage across all skill executor calls.
+
+State file: ~/secondbrain/usage-tracker-state.json
+Shape:
+  {
+    "YYYY-MM-DD": {
+      "<model-id>": {
+        "prompt_tokens": int,
+        "completion_tokens": int,
+        "calls": int
+      }
+    }
+  }
+
+Usage recording is best-effort — failures are logged but never raised.
+"""
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+log = logging.getLogger("usage-tracker")
+
+DEPLOY_DIR = Path(os.environ.get("SECOND_BRAIN_DIR", str(Path.home() / "secondbrain")))
+USAGE_STATE_FILE = DEPLOY_DIR / "usage-tracker-state.json"
+RETENTION_DAYS = 30
+
+
+def _load_state(state_file: Path) -> dict:
+    if state_file.exists():
+        try:
+            return json.loads(state_file.read_text())
+        except Exception as e:
+            log.warning("Failed to load usage state: %s", e)
+    return {}
+
+
+def _save_state(state: dict, state_file: Path) -> None:
+    tmp = state_file.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(state, indent=2))
+        os.rename(str(tmp), str(state_file))
+    except Exception as e:
+        log.error("Failed to save usage state: %s", e)
+
+
+def _prune_old_days(state: dict, retention_days: int) -> dict:
+    cutoff = (datetime.now() - timedelta(days=retention_days)).strftime("%Y-%m-%d")
+    return {k: v for k, v in state.items() if k >= cutoff}
+
+
+def record_usage(
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    state_file: Path = USAGE_STATE_FILE,
+) -> None:
+    """Record token usage for one LLM API call. Best-effort — never raises."""
+    if not prompt_tokens and not completion_tokens:
+        return
+    try:
+        state = _load_state(state_file)
+        today = datetime.now().strftime("%Y-%m-%d")
+        day = state.setdefault(today, {})
+        entry = day.setdefault(model, {"prompt_tokens": 0, "completion_tokens": 0, "calls": 0})
+        entry["prompt_tokens"] += prompt_tokens
+        entry["completion_tokens"] += completion_tokens
+        entry["calls"] += 1
+        state = _prune_old_days(state, RETENTION_DAYS)
+        _save_state(state, state_file)
+    except Exception as e:
+        log.debug("record_usage failed (non-fatal): %s", e)
+
+
+def render_usage(days: int = 7, state_file: Path = USAGE_STATE_FILE) -> str:
+    """Return a human-readable usage summary for the last *days* days."""
+    state = _load_state(state_file)
+    cutoff = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+
+    totals: dict[str, dict] = {}
+    for date, day_data in sorted(state.items()):
+        if date < cutoff:
+            continue
+        for model, usage in day_data.items():
+            entry = totals.setdefault(model, {"prompt_tokens": 0, "completion_tokens": 0, "calls": 0})
+            entry["prompt_tokens"] += usage.get("prompt_tokens", 0)
+            entry["completion_tokens"] += usage.get("completion_tokens", 0)
+            entry["calls"] += usage.get("calls", 0)
+
+    if not totals:
+        return f"No usage data for the last {days} day(s). Usage is recorded automatically as skills run."
+
+    lines = [f"Token usage — last {days} day(s):"]
+    grand_prompt = grand_completion = 0
+    for model, data in sorted(totals.items()):
+        p = data["prompt_tokens"]
+        c = data["completion_tokens"]
+        n = data["calls"]
+        grand_prompt += p
+        grand_completion += c
+        lines.append(f"  {model}: {p:,} in + {c:,} out ({n} call{'s' if n != 1 else ''})")
+
+    lines.append(f"Total: {grand_prompt + grand_completion:,} tokens across all models")
+    return "\n".join(lines)
+
+
+def render_daily_breakdown(state_file: Path = USAGE_STATE_FILE) -> str:
+    """Return per-day totals for the last 7 days (compact view)."""
+    state = _load_state(state_file)
+    cutoff = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+
+    lines = ["Daily token totals (last 7 days):"]
+    found_any = False
+    for date in sorted(state.keys()):
+        if date < cutoff:
+            continue
+        day_data = state[date]
+        day_total = sum(
+            v.get("prompt_tokens", 0) + v.get("completion_tokens", 0)
+            for v in day_data.values()
+        )
+        lines.append(f"  {date}: {day_total:,} tokens")
+        found_any = True
+
+    if not found_any:
+        return "No daily usage data available."
+    return "\n".join(lines)

--- a/usage_tracker.py
+++ b/usage_tracker.py
@@ -46,7 +46,7 @@ def _save_state(state: dict, state_file: Path) -> None:
 
 
 def _prune_old_days(state: dict, retention_days: int) -> dict:
-    cutoff = (datetime.now() - timedelta(days=retention_days)).strftime("%Y-%m-%d")
+    cutoff = (datetime.now() - timedelta(days=retention_days - 1)).strftime("%Y-%m-%d")
     return {k: v for k, v in state.items() if k >= cutoff}
 
 
@@ -76,7 +76,7 @@ def record_usage(
 def render_usage(days: int = 7, state_file: Path = USAGE_STATE_FILE) -> str:
     """Return a human-readable usage summary for the last *days* days."""
     state = _load_state(state_file)
-    cutoff = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+    cutoff = (datetime.now() - timedelta(days=days - 1)).strftime("%Y-%m-%d")
 
     totals: dict[str, dict] = {}
     for date, day_data in sorted(state.items()):
@@ -108,7 +108,7 @@ def render_usage(days: int = 7, state_file: Path = USAGE_STATE_FILE) -> str:
 def render_daily_breakdown(state_file: Path = USAGE_STATE_FILE) -> str:
     """Return per-day totals for the last 7 days (compact view)."""
     state = _load_state(state_file)
-    cutoff = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+    cutoff = (datetime.now() - timedelta(days=6)).strftime("%Y-%m-%d")
 
     lines = ["Daily token totals (last 7 days):"]
     found_any = False

--- a/zoom_scanner.py
+++ b/zoom_scanner.py
@@ -14,6 +14,7 @@ import httpx
 import yaml
 
 from llm_routes import resolve
+from usage_tracker import record_usage
 from secrets import get_secret_or_env
 from utils import load_config
 
@@ -339,6 +340,8 @@ class ZoomScanner:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             text = re.sub(r'^```(?:json)?\n?', '', text)
             text = re.sub(r'\n?```$', '', text)
@@ -658,6 +661,8 @@ class ZoomScanner:
                 messages=[{"role": "user", "content": prompt}],
                 timeout=30,
             )
+            if hasattr(resp, "usage") and resp.usage:
+                record_usage(resolve("summarize"), resp.usage.prompt_tokens or 0, resp.usage.completion_tokens or 0)
             text = resp.choices[0].message.content.strip()
             text = re.sub(r'^```(?:json)?\n?', '', text)
             text = re.sub(r'\n?```$', '', text)


### PR DESCRIPTION
## Summary

- **`usage_tracker.py`** — new module that records `prompt_tokens` + `completion_tokens` per model per day into `~/secondbrain/usage-tracker-state.json`. 30-day rolling retention, atomic writes, best-effort (failures log at DEBUG and never propagate).
- **`skill_executor.py`** — calls `record_usage()` after every successful `acompletion()` in both `run()` and `run_with_tools()`, covering all skill calls and the chat tool-call loop.
- **`/usage [days]`** — new Telegram command showing per-model token totals for the last N days (default 7). `/usage daily` shows a per-day rolling breakdown.

## Test plan

- [x] `pytest` — 1422 passed, 0 failed
- [x] 14 unit tests in `tests/unit/test_usage_tracker.py` cover accumulation, atomic writes, pruning, zero-skip, and exception safety
- [x] `test_usage_smoke` in `test_e2e_meta_system.py`
- [x] `test_every_registry_command_has_smoke_test` passes (registry + handler are consistent)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)