### PR TITLE
feat(/pending): unified inbox for all pending review items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `/pending` Telegram command: unified inbox showing the count of all items awaiting human review — project/repo candidates, pending agent actions, and skill drafts. Points to `/review`, `/actions`, and `/skill_drafts` for detail (#20).
 - `/todos` Telegram command: shows all active commitments as a `[ ]` checklist. Supports `/todos done N [M…]` to mark complete and `/todos dismiss N` to dismiss. Personal todos are shown without a type tag; extracted commitments show their type in brackets (e.g. `[outbound]`). Populates the shared commitment index so `/complete N` also works after a `/todos` listing (#51).
 - `usage_tracker`: records prompt/completion token counts per model per day from every LiteLLM call in `skill_executor`. State stored in `~/secondbrain/usage-tracker-state.json` with 30-day retention (#13).
 - `/usage [days]` Telegram command: shows token usage totals per model for the last N days (default 7). `/usage daily` shows a per-day rolling total. Works across all models routed through LiteLLM (#13).

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -2147,7 +2147,7 @@ class TelegramChatHandler:
 
     # ── Agent actions commands ────────────────────────────────────────────────
 
-    def _load_action_set(self, filter_status: Optional[str] = None) -> list:
+    def _load_action_set(self, filter_status: Optional[str] = None, update_last_set: bool = True) -> list:
         """Load action-*.md files and filter by status. Returns list of (path, fm) tuples."""
         actions = []
         now = datetime.now()
@@ -2188,7 +2188,8 @@ class TelegramChatHandler:
 
         # Sort by proposed_at descending
         actions.sort(key=lambda x: x[1].get("proposed_at", ""), reverse=True)
-        self._last_action_set = actions
+        if update_last_set:
+            self._last_action_set = actions
         return actions
 
     async def cmd_actions(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -3539,8 +3540,8 @@ class TelegramChatHandler:
             if fm.get("type") == "project_candidate" and fm.get("status") == "pending_confirmation":
                 candidate_count += 1
 
-        # Agent actions
-        actions = self._load_action_set()
+        # Agent actions — count only; must not clobber _last_action_set
+        actions = self._load_action_set(update_last_set=False)
         action_count = len(actions)
 
         # Skill drafts

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -192,6 +192,7 @@ class TelegramChatHandler:
         self.app.add_handler(CommandHandler("report_resume", self.cmd_report_resume))
         self.app.add_handler(CommandHandler("report_run", self.cmd_report_run))
         # Review
+        self.app.add_handler(CommandHandler("pending", self.cmd_pending))
         self.app.add_handler(CommandHandler("review", self.cmd_review))
         self.app.add_handler(CommandHandler("confirm", self.cmd_confirm))
         self.app.add_handler(CommandHandler("reject", self.cmd_reject))
@@ -3521,6 +3522,52 @@ class TelegramChatHandler:
 
         else:
             return f"Unknown candidate type: {candidate_type}"
+
+    async def cmd_pending(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Unified inbox: count all pending review items across candidates, actions, and skill drafts."""
+        if not self._check_auth(update):
+            return
+
+        # Project candidates
+        rows = await self._cache.query_by_prefix("project-candidate")
+        candidate_count = 0
+        for row in rows:
+            try:
+                fm = json.loads(row["frontmatter"]) if isinstance(row["frontmatter"], str) else row["frontmatter"]
+            except Exception:
+                continue
+            if fm.get("type") == "project_candidate" and fm.get("status") == "pending_confirmation":
+                candidate_count += 1
+
+        # Agent actions
+        actions = self._load_action_set()
+        action_count = len(actions)
+
+        # Skill drafts
+        draft_count = 0
+        if self.skill_creator is not None:
+            try:
+                draft_count = len(self.skill_creator.list_pending_drafts())
+            except Exception:
+                pass
+
+        total = candidate_count + action_count + draft_count
+
+        if total == 0:
+            await update.message.reply_text("Nothing pending review.")
+            return
+
+        lines = [f"Pending review ({total} total):", ""]
+        if candidate_count:
+            noun = "candidate" if candidate_count == 1 else "candidates"
+            lines.append(f"• {candidate_count} project {noun} — /review")
+        if action_count:
+            noun = "action" if action_count == 1 else "actions"
+            lines.append(f"• {action_count} agent {noun} — /actions")
+        if draft_count:
+            noun = "draft" if draft_count == 1 else "drafts"
+            lines.append(f"• {draft_count} skill {noun} — /skill_drafts")
+        await update.message.reply_text("\n".join(lines))
 
     async def cmd_review(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """List pending project/repo candidates, or show detail of candidate N."""

--- a/command_core.py
+++ b/command_core.py
@@ -75,6 +75,7 @@ COMMAND_REGISTRY: dict[str, list[tuple[str, str]]] = {
         ("changes",         "Project/goal activity digest for the last N hours. /changes [hours] (default 24)"),
     ],
     "Review": [
+        ("pending",  "Unified inbox — count of all pending review items (candidates, actions, skill drafts)"),
         ("review",   "List pending project/repo candidates (/review N for detail)"),
         ("confirm",  "Confirm candidate N (/confirm N [category])"),
         ("reject",   "Reject candidate N"),

--- a/tests/integration/test_e2e_review.py
+++ b/tests/integration/test_e2e_review.py
@@ -4,6 +4,12 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
+async def test_pending_smoke(handler, mk_update, brain_dir):
+    update, ctx = mk_update("/pending")
+    await handler.cmd_pending(update, ctx)
+    update.message.reply_text.assert_called()
+
+
 async def test_review_smoke(handler, mk_update, brain_dir):
     from tests.integration import seed
     seed.candidate(brain_dir)

--- a/tests/unit/test_chat_handler.py
+++ b/tests/unit/test_chat_handler.py
@@ -3107,6 +3107,66 @@ async def test_load_context_includes_goal_project_context(handler, brain_dir):
     # Goal should still appear in context
     assert "## Active Goals" in context
     assert "Run a 5K" in context
+# --- /pending unified inbox ---
+
+@pytest.mark.asyncio
+async def test_cmd_pending_all_empty(handler, brain_dir):
+    """/pending with nothing queued returns 'Nothing pending review.'"""
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_pending(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "Nothing pending review" in reply
+
+
+@pytest.mark.asyncio
+async def test_cmd_pending_shows_candidates_and_actions(handler, brain_dir):
+    """/pending aggregates project candidates and agent actions into one summary."""
+    mem_dir = brain_dir / "memories"
+
+    # Write two pending candidates
+    for slug, ctype in [("rollout-abc123", "project"), ("repo-def456", "code_repo")]:
+        (mem_dir / f"project-candidate-{slug}.md").write_text(
+            f"---\ntype: project_candidate\ncandidate_type: {ctype}\n"
+            "status: pending_confirmation\ncreated: '2026-04-15T09:00:00'\n---\n"
+        )
+
+    # Write one pending action
+    write_action(mem_dir, "aaa111", "add_note", "project-test.md", status="pending")
+    # Write one already-executed action (should not be counted)
+    write_action(mem_dir, "bbb222", "add_note", "project-test.md", status="executed")
+
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_pending(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+
+    assert "Pending review (3 total)" in reply
+    assert "2 project candidates" in reply
+    assert "/review" in reply
+    assert "1 agent action" in reply
+    assert "/actions" in reply
+
+
+@pytest.mark.asyncio
+async def test_cmd_pending_skips_confirmed_candidates(handler, brain_dir):
+    """/pending only counts status: pending_confirmation candidates, not confirmed ones."""
+    mem_dir = brain_dir / "memories"
+    (mem_dir / "project-candidate-done-abc123.md").write_text(
+        "---\ntype: project_candidate\ncandidate_type: project\n"
+        "status: confirmed\ncreated: '2026-04-15T09:00:00'\n---\n"
+    )
+    (mem_dir / "project-candidate-pending-def456.md").write_text(
+        "---\ntype: project_candidate\ncandidate_type: project\n"
+        "status: pending_confirmation\ncreated: '2026-04-15T10:00:00'\n---\n"
+    )
+
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_pending(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+
+    assert "Pending review (1 total)" in reply
+    assert "1 project candidate" in reply
+
+
 # --- Review commands ---
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chat_handler.py
+++ b/tests/unit/test_chat_handler.py
@@ -4260,6 +4260,43 @@ async def test_cmd_defer_sets_defer_until_and_hides_from_default_list(handler, b
     assert "No pending agent actions" in reply2 or "0" in reply2
 
 
+# ── /pending must not clobber _last_action_set ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_pending_does_not_clobber_last_action_set(handler, brain_dir):
+    """/pending count check must not overwrite _last_action_set.
+
+    If a user loads /actions then calls /pending (a summary-only inbox count),
+    the subsequent /action N / /run N commands must still target the set that
+    /actions loaded — not the smaller 'pending only' set that /pending counts.
+    """
+    m = brain_dir / "memories"
+    # Write two pending actions plus one approved action
+    write_action(m, "aaa111", "add_milestone", "goal-test.md", status="pending")
+    write_action(m, "bbb222", "update_status", "goal-test.md", status="pending")
+    write_action(m, "ccc333", "add_note",      "goal-test.md", status="approved")
+
+    # 1. User loads all actions (/actions all → 3 items in _last_action_set)
+    u1, c1 = _make_update(12345, args=["all"])
+    await handler.cmd_actions(u1, c1)
+    all_set_before = list(handler._last_action_set)
+    assert len(all_set_before) == 3
+
+    # 2. User calls /pending (count-only, must NOT replace _last_action_set)
+    u2, c2 = _make_update(12345)
+    from unittest.mock import AsyncMock, MagicMock, patch
+    mock_cache = MagicMock()
+    mock_cache.query_by_prefix = AsyncMock(return_value=[])
+    with patch.object(handler, "_cache", mock_cache):
+        await handler.cmd_pending(u2, c2)
+
+    # _last_action_set must still be the 3-item "all" set
+    assert handler._last_action_set == all_set_before, (
+        "/pending must not overwrite _last_action_set; got "
+        f"{len(handler._last_action_set)} items instead of 3"
+    )
+
+
 # ── _resolve_feature_index hash fallback (fix fcfc1f) ─────────────────────────
 
 def test_resolve_feature_by_hash(handler, brain_dir):


### PR DESCRIPTION
## Summary

- `/pending` was missing as a way to see all items needing human attention across the three HITL systems
- Before this PR, you had to check `/review`, `/actions`, and `/skill_drafts` separately to know what needed review
- `/pending` now shows a single count summary with pointers to the relevant detail commands

## Changes

- `command_core.py`: added `pending` to the "Review" group in COMMAND_REGISTRY
- `chat_handler.py`: `CommandHandler` registration + `cmd_pending()` — aggregates project candidate count (cache query), action count (filesystem glob), and skill draft count (skill_creator if available)
- `tests/unit/test_chat_handler.py`: 3 new unit tests (all empty, mixed items, skips non-pending candidates)
- `tests/integration/test_e2e_review.py`: `test_pending_smoke` so registry coverage passes
- `CHANGELOG.md`: entry under `[Unreleased] → Added`

## Test plan

- [x] `pytest tests/unit/test_chat_handler.py -k test_cmd_pending` — 3 passed
- [x] `pytest tests/integration/test_e2e_registry_coverage.py` — passed (pending in coverage)
- [x] `pytest` (full suite) — 1439 passed, 0 failed

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)