### PR TITLE
Fix overdue deliverables not shown as past-due in /commitments, /todos, /goals, /projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `install.sh` now runs a Python smoke import (`import daemon` + `from chat_handler import TelegramChatHandler` on full role) after deploying source files and before reloading launchd. If the deployed artefact would crash at import time, the installer exits 1 and leaves the running daemon untouched.
 
 ### Fixed
+- `/commitments`, `/todos`: past-due active items now display `was due <date> ⚠️` instead of the bare date, so overdue deliverables are visually flagged rather than silently showing a stale date. Same fix applied to `/goals` (shows `was due <date> ⚠️ OVERDUE`) and `/projects` (shows `was due <date> ⚠️ OVERDUE`) (#103).
 - `notification_manager`: malformed or null frontmatter in any memory-cache entry no longer aborts `_assemble_briefing`, `_check_commitment_alerts`, or `_check_pre_meeting_alerts` — each `json.loads` call is now individually guarded by `try/except (JSONDecodeError, TypeError)`. Additionally, `_check_and_send` now runs each check (`_check_daily_briefing`, `_check_commitment_alerts`, etc.) in its own `try/except` so a single failing check cannot silence subsequent ones (#52).
 - `usage_tracker.record_usage`: read-modify-write on the state JSON is now protected by a module-level `threading.Lock`, preventing lost increments when multiple async loops call it concurrently (#13).
 - `skill_optimizer`: all four `acompletion` call sites now record token usage via `record_usage`, so `/usage` totals include judge and optimizer traffic (#13).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `/project_note <N> <text>` — append a timestamped note to a project conversationally (#18).
 - `/project_due <N> <YYYY-MM-DD|none>` — update or clear a project's due date (#18).
 - `/changes [hours]` Telegram command: scans all active goals and projects, finds related memory files updated in the last N hours (default 24, max 168), and sends a concise LLM-generated activity digest per item — one paragraph per project/goal with recent activity. Implemented in `GoalProjectAgent.generate_change_digest()` (#74).
+- `install.sh` now runs a Python smoke import (`import daemon` + `from chat_handler import TelegramChatHandler` on full role) after deploying source files and before reloading launchd. If the deployed artefact would crash at import time, the installer exits 1 and leaves the running daemon untouched.
 
 ### Fixed
 - `notification_manager`: malformed or null frontmatter in any memory-cache entry no longer aborts `_assemble_briefing`, `_check_commitment_alerts`, or `_check_pre_meeting_alerts` — each `json.loads` call is now individually guarded by `try/except (JSONDecodeError, TypeError)`. Additionally, `_check_and_send` now runs each check (`_check_daily_briefing`, `_check_commitment_alerts`, etc.) in its own `try/except` so a single failing check cannot silence subsequent ones (#52).

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -1628,14 +1628,22 @@ class TelegramChatHandler:
         total = len(items)
         lines = [f"Active commitments ({total} total):"]
 
+        today = datetime.now().date()
         for i, (_, fm) in enumerate(items[:limit], 1):
             ct = fm.get("commitment_type", "outbound")
             desc = (fm.get("source_title") or fm.get("summary") or "")[:50]
             owner = fm.get("owner", "")
             due = fm.get("due_date")
-            due_str = f" — due {due}" if due else " — due unknown"
+            if due:
+                try:
+                    overdue = datetime.strptime(str(due), "%Y-%m-%d").date() < today
+                except ValueError:
+                    overdue = False
+                due_str = f" — was due {due} ⚠️" if overdue else f" — due {due}"
+            else:
+                due_str = " — due unknown"
             needs_review = "needs-review" in (fm.get("tags") or [])
-            flag = " ⚠️" if needs_review else ""
+            flag = " ⚠️" if needs_review and not due_str.endswith("⚠️") else ""
             lines.append(f"{i}. [{ct}] {desc} — {owner}{due_str}{flag}")
 
         if total > limit:
@@ -1702,14 +1710,22 @@ class TelegramChatHandler:
             self._active_list = self._last_commitment_set
             total = len(items)
             lines = [f"Active {type_filter} commitments ({total} total):"]
+            today = datetime.now().date()
             for i, (_, fm) in enumerate(items[:20], 1):
                 ct = fm.get("commitment_type", "outbound")
                 desc = (fm.get("source_title") or fm.get("summary") or "")[:50]
                 owner = fm.get("owner", "")
                 due = fm.get("due_date")
-                due_str = f" — due {due}" if due else " — due unknown"
+                if due:
+                    try:
+                        overdue = datetime.strptime(str(due), "%Y-%m-%d").date() < today
+                    except ValueError:
+                        overdue = False
+                    due_str = f" — was due {due} ⚠️" if overdue else f" — due {due}"
+                else:
+                    due_str = " — due unknown"
                 needs_review = "needs-review" in (fm.get("tags") or [])
-                flag = " ⚠️" if needs_review else ""
+                flag = " ⚠️" if needs_review and not due_str.endswith("⚠️") else ""
                 lines.append(f"{i}. [{ct}] {desc} — {owner}{due_str}{flag}")
             if total > 20:
                 lines.append(f"... and {total - 20} more.")
@@ -1736,14 +1752,22 @@ class TelegramChatHandler:
         total = len(items)
         lines = [f"Todos ({total}):"]
 
+        today = datetime.now().date()
         for i, (_, fm) in enumerate(items, 1):
             desc = (fm.get("source_title") or fm.get("summary") or "")[:55]
             due = fm.get("due_date")
-            due_str = f" — due {due}" if due else ""
+            if due:
+                try:
+                    overdue = datetime.strptime(str(due), "%Y-%m-%d").date() < today
+                except ValueError:
+                    overdue = False
+                due_str = f" — was due {due} ⚠️" if overdue else f" — due {due}"
+            else:
+                due_str = ""
             ct = fm.get("commitment_type", "outbound")
             type_hint = f" [{ct}]" if ct != "personal" else ""
             needs_review = "needs-review" in (fm.get("tags") or [])
-            flag = " ⚠️" if needs_review else ""
+            flag = " ⚠️" if needs_review and not due_str.endswith("⚠️") else ""
             lines.append(f"{i}. [ ] {desc}{due_str}{type_hint}{flag}")
 
         lines.append("\n/todos done N  — complete  |  /todos dismiss N  — dismiss")
@@ -2644,21 +2668,22 @@ class TelegramChatHandler:
                 cat = fm.get("category", "")
                 title = fm.get("source_title", "")
                 due = fm.get("due_date")
-                due_str = f"due {due}" if due else "no due date"
-
-                # Add deadline proximity indicator if within 7 days
-                proximity = ""
                 if due:
                     try:
                         due_dt = datetime.strptime(due, "%Y-%m-%d")
-                        now = datetime.now()
-                        days_until = (due_dt - now).days
-                        if 0 <= days_until <= 7:
-                            proximity = f" ⚠️ {days_until} days"
+                        days_until = (due_dt - datetime.now()).days
+                        if days_until < 0:
+                            due_str = f"was due {due} ⚠️ OVERDUE"
+                        elif days_until <= 7:
+                            due_str = f"due {due} ⚠️ {days_until} days"
+                        else:
+                            due_str = f"due {due}"
                     except ValueError:
-                        pass
+                        due_str = f"due {due}"
+                else:
+                    due_str = "no due date"
 
-                lines.append(f"{i}. [{cat}] {title} — {due_str}{proximity}")
+                lines.append(f"{i}. [{cat}] {title} — {due_str}")
 
             await update.message.reply_text("\n".join(lines))
         except Exception as e:
@@ -2899,6 +2924,7 @@ class TelegramChatHandler:
             return "No active projects found."
 
         lines = [f"Active projects ({len(projects)} total):"]
+        today = datetime.now().date()
 
         for i, path in enumerate(projects[:limit], 1):
             fm = self._parse_frontmatter(path)
@@ -2906,7 +2932,14 @@ class TelegramChatHandler:
             title = fm.get("source_title", "")
             proj_status = fm.get("status", "")
             due = fm.get("due_date")
-            due_str = f"due {due}" if due else "no due date"
+            if due:
+                try:
+                    overdue = datetime.strptime(str(due), "%Y-%m-%d").date() < today
+                except ValueError:
+                    overdue = False
+                due_str = f"was due {due} ⚠️ OVERDUE" if overdue else f"due {due}"
+            else:
+                due_str = "no due date"
 
             milestones = fm.get("milestones", [])
             if milestones:
@@ -2949,13 +2982,21 @@ class TelegramChatHandler:
                     await update.message.reply_text("No projects found.")
                     return
                 lines = [f"{status.capitalize() if status else 'All'} projects ({len(projects)} total):"]
+                today = datetime.now().date()
                 for i, path in enumerate(projects, 1):
                     fm = self._parse_frontmatter(path)
                     cat = fm.get("category", "")
                     title = fm.get("source_title", "")
                     proj_status = fm.get("status", "")
                     due = fm.get("due_date")
-                    due_str = f"due {due}" if due else "no due date"
+                    if due:
+                        try:
+                            overdue = datetime.strptime(str(due), "%Y-%m-%d").date() < today
+                        except ValueError:
+                            overdue = False
+                        due_str = f"was due {due} ⚠️ OVERDUE" if overdue else f"due {due}"
+                    else:
+                        due_str = "no due date"
                     milestones = fm.get("milestones", [])
                     if milestones:
                         done_count = sum(1 for m in milestones if m.get("done"))

--- a/install.sh
+++ b/install.sh
@@ -499,7 +499,7 @@ echo "Checking Python dependencies..."
 REQS_HASH_FILE="$DEPLOY_DIR/.requirements-hash"
 if [ "$ROLE" = "watcher" ]; then
     # Fixed set for watcher — hash the package names directly
-    REQS_HASH="$(echo 'litellm httpx beautifulsoup4 lxml pyyaml pyobjc-framework-EventKit' | shasum -a 256 | cut -d' ' -f1)"
+    REQS_HASH="$(echo 'litellm httpx beautifulsoup4 lxml pyyaml pyobjc-framework-EventKit pdfminer.six' | shasum -a 256 | cut -d' ' -f1)"
 else
     REQS_HASH="$(shasum -a 256 "$REPO_DIR/requirements.txt" | cut -d' ' -f1)"
 fi
@@ -510,7 +510,7 @@ else
     info "Installing dependencies..."
     "$VENV/bin/pip" install -q --upgrade pip
     if [ "$ROLE" = "watcher" ]; then
-        "$VENV/bin/pip" install -q litellm httpx beautifulsoup4 lxml pyyaml pyobjc-framework-EventKit
+        "$VENV/bin/pip" install -q litellm httpx beautifulsoup4 lxml pyyaml pyobjc-framework-EventKit pdfminer.six
     else
         "$VENV/bin/pip" install -q -r "$REPO_DIR/requirements.txt"
     fi
@@ -586,7 +586,27 @@ for FILE in "${DAEMON_FILES[@]}"; do
 done
 [ "$deployed" -eq 0 ] && info "All source files already up to date" || ok "$deployed file(s) deployed"
 
-# ── 10. iCloud directory structure ────────────────────────────────────────────
+# ── 9. Smoke import: verify deployed daemon imports cleanly ──────────────────
+echo ""
+echo "Verifying daemon imports cleanly..."
+SMOKE_SCRIPT='import daemon'
+if [ "$ROLE" = "full" ]; then
+    SMOKE_SCRIPT="$SMOKE_SCRIPT
+from chat_handler import TelegramChatHandler"
+fi
+if SMOKE_OUTPUT="$(cd "$DEPLOY_DIR" && "$VENV/bin/python3" -c "$SMOKE_SCRIPT" 2>&1)"; then
+    ok "Import check passed"
+else
+    die "Import check failed — refusing to reload daemon
+
+$SMOKE_OUTPUT
+
+  The deployed daemon would crash at startup. Fix the import
+  error and re-run ./install.sh. The previous daemon (if any)
+  is still running and has NOT been touched."
+fi
+
+# ── 11. iCloud directory structure ────────────────────────────────────────────
 echo ""
 echo "Setting up iCloud directories..."
 for DIR in memories skills inbox; do
@@ -599,7 +619,7 @@ for DIR in memories skills inbox; do
     fi
 done
 
-# ── 11. config.yaml ───────────────────────────────────────────────────────────
+# ── 12. config.yaml ───────────────────────────────────────────────────────────
 echo ""
 echo "Writing config.yaml..."
 if [ -f "$CONFIG_DEST" ]; then
@@ -624,7 +644,7 @@ PYEOF
     ok "Created $CONFIG_DEST"
 fi
 
-# ── 12. Skill files ───────────────────────────────────────────────────────────
+# ── 13. Skill files ───────────────────────────────────────────────────────────
 echo ""
 echo "Installing skill files..."
 for SKILL in "$REPO_DIR/skills/"*.md; do
@@ -637,13 +657,13 @@ for SKILL in "$REPO_DIR/skills/"*.md; do
     fi
 done
 
-# ── 12b. Apply LLM provider preference to deployed skills ─────────────────────
+# ── 13b. Apply LLM provider preference to deployed skills ─────────────────────
 echo ""
 echo "Applying LLM provider preference to skill files..."
 PROVIDER="$PROVIDER" "$VENV/bin/python3" "$REPO_DIR/scripts/apply_skill_provider.py" \
     "$BRAIN_DIR/skills"
 
-# ── 12c. Generate skill file checksums ───────────────────────────────────────
+# ── 13c. Generate skill file checksums ───────────────────────────────────────
 echo ""
 echo "Generating skill file checksums..."
 CHECKSUM_FILE="$DEPLOY_DIR/skill-checksums.json"
@@ -676,7 +696,7 @@ print(f"  ✓  Wrote skill checksums ({len(manifest)} skills)")
 PYEOF
 chmod 600 "$CHECKSUM_FILE"
 
-# ── 13. LiteLLM config ────────────────────────────────────────────────────────
+# ── 14. LiteLLM config ────────────────────────────────────────────────────────
 echo ""
 echo "Setting up LiteLLM config..."
 if [ -f "$LITELLM_CONFIG" ]; then
@@ -710,7 +730,7 @@ LITELLM_EOF
     ok "Created $LITELLM_CONFIG"
 fi
 
-# ── 14. launchd plist ─────────────────────────────────────────────────────────
+# ── 15. launchd plist ─────────────────────────────────────────────────────────
 echo ""
 echo "Configuring launchd agent..."
 
@@ -776,7 +796,7 @@ else
     PLIST_CHANGED=true
 fi
 
-# ── 15. Load (or reload) the agent ────────────────────────────────────────────
+# ── 16. Load (or reload) the agent ────────────────────────────────────────────
 NEEDS_RELOAD=false
 [ "$deployed" -gt 0 ] && NEEDS_RELOAD=true
 [ "$PLIST_CHANGED" = "true" ] && NEEDS_RELOAD=true
@@ -797,7 +817,7 @@ else
     fi
 fi
 
-# ── 16. Full Disk Access check (both roles) ───────────────────────────────────
+# ── 17. Full Disk Access check (both roles) ───────────────────────────────────
 echo ""
 echo "Checking Full Disk Access for email scanner..."
 

--- a/tests/unit/_manifest_helpers.py
+++ b/tests/unit/_manifest_helpers.py
@@ -1,0 +1,135 @@
+"""Shared helpers for deployment-manifest tests.
+
+Used by test_install_manifest.py, test_requirements_manifest.py, and
+test_watcher_role_packages.py to verify that the DAEMON_FILES array in
+install.sh, the requirements.txt pin list, and the watcher pip install
+list all stay consistent with the actual import closure from daemon.py.
+"""
+import ast
+import importlib.util
+import re
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Set
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+# Import names that differ from their PyPI distribution name.
+# Keys are what appears in import statements; values are the distribution
+# name as written in requirements.txt (before version specifiers).
+IMPORT_TO_DISTRIBUTION: dict[str, str] = {
+    "yaml":       "pyyaml",
+    "bs4":        "beautifulsoup4",
+    "telegram":   "python-telegram-bot",
+    "EventKit":   "pyobjc-framework-EventKit",
+    "pdfminer":   "pdfminer.six",
+    "slack_bolt": "slack_bolt",
+    # Foundation is provided by pyobjc-framework-Cocoa, which is a transitive
+    # dependency of pyobjc-framework-EventKit (not directly in requirements.txt)
+    "Foundation": "pyobjc-framework-EventKit",
+}
+
+
+def _local_imports(path: Path) -> Set[str]:
+    """Return local-module names directly imported by path (non-recursive)."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.level == 0:
+                names.add(node.module.split(".")[0])
+    return {n for n in names if (REPO_ROOT / f"{n}.py").exists()}
+
+
+def _import_closure(entry: Path) -> Set[str]:
+    """Transitive closure of local-module imports from entry point, as .py filenames."""
+    visited: Set[str] = set()
+    frontier = {entry.stem}
+    while frontier:
+        name = frontier.pop()
+        if name in visited:
+            continue
+        visited.add(name)
+        py = REPO_ROOT / f"{name}.py"
+        if py.exists():
+            frontier |= _local_imports(py)
+    # Return as filenames, not module names
+    return {f"{n}.py" for n in visited}
+
+
+def _is_stdlib(name: str) -> bool:
+    """Return True if name is a stdlib module on the current Python."""
+    # Python 3.10+ has sys.stdlib_module_names
+    if hasattr(sys, "stdlib_module_names"):
+        return name in sys.stdlib_module_names
+
+    # Fallback: check if find_spec resolves to stdlib path or is a builtin
+    try:
+        spec = importlib.util.find_spec(name)
+        if spec is None:
+            return False
+        origin = getattr(spec, "origin", None)
+        if origin is None:
+            return False
+        # Builtins have origin="built-in"
+        if origin == "built-in":
+            return True
+        # Standard library modules live in the stdlib path
+        stdlib_path = sysconfig.get_paths()["stdlib"]
+        return origin.startswith(stdlib_path)
+    except (ImportError, ValueError, AttributeError):
+        return False
+
+
+def dist_for(import_name: str) -> str:
+    """Map an import-name to its PyPI distribution name (lowercase, - not _)."""
+    mapped = IMPORT_TO_DISTRIBUTION.get(import_name, import_name)
+    return mapped.lower().replace("_", "-")
+
+
+def third_party_imports_in(entry_modules: list[str]) -> Set[str]:
+    """Return all third-party import names reachable from a list of module names.
+
+    This computes the transitive closure of local modules from each entry point,
+    then scans every module in that closure for non-local, non-stdlib imports.
+    Returns import *names* (not distribution names).
+    """
+    # Compute union of local closures
+    all_local_names: Set[str] = set()
+    for mod in entry_modules:
+        py = REPO_ROOT / f"{mod}.py"
+        if py.exists():
+            closure_filenames = _import_closure(py)
+            all_local_names |= {f[:-3] for f in closure_filenames}
+
+    # Now collect ALL imports (including third-party) from those modules
+    third_party: Set[str] = set()
+    for name in all_local_names:
+        py = REPO_ROOT / f"{name}.py"
+        if not py.exists():
+            continue
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top = alias.name.split(".")[0]
+                    if not (REPO_ROOT / f"{top}.py").exists() and not _is_stdlib(top):
+                        third_party.add(top)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module and node.level == 0:
+                    top = node.module.split(".")[0]
+                    if not (REPO_ROOT / f"{top}.py").exists() and not _is_stdlib(top):
+                        third_party.add(top)
+    return third_party
+
+
+def parse_daemon_files() -> Set[str]:
+    """Extract the DAEMON_FILES array from install.sh."""
+    text = (REPO_ROOT / "install.sh").read_text()
+    m = re.search(r"DAEMON_FILES=\(\s*(.*?)\s*\)", text, re.DOTALL)
+    assert m, "Could not find DAEMON_FILES array in install.sh"
+    return set(m.group(1).split())

--- a/tests/unit/test_chat_handler.py
+++ b/tests/unit/test_chat_handler.py
@@ -3763,6 +3763,40 @@ async def test_cmd_goal_unknown_verb_shows_registry_help(handler, brain_dir):
     assert "/completegoal" in reply
     assert "/abandongoal" in reply
 
+
+@pytest.mark.asyncio
+async def test_cmd_goals_overdue_shows_was_due(handler, brain_dir):
+    """/goals marks past-due active goals with 'was due … OVERDUE'."""
+    m = brain_dir / "memories"
+    (m / "goal-old-abc123.md").write_text(
+        "---\ntype: goal\ncategory: personal\nsource_title: Overdue Goal\n"
+        "summary: ''\ntags: []\ncreated: '2024-01-01T09:00:00'\n"
+        "due_date: '2024-01-01'\nstatus: active\npriority: medium\n"
+        "linked_projects: []\nnotes: ''\n---\n\n## Notes\n"
+    )
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_goals(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "was due 2024-01-01" in reply
+    assert "OVERDUE" in reply
+
+
+@pytest.mark.asyncio
+async def test_cmd_goals_future_due_shows_due(handler, brain_dir):
+    """/goals shows plain 'due' for goals not yet past their deadline."""
+    m = brain_dir / "memories"
+    (m / "goal-future-abc123.md").write_text(
+        "---\ntype: goal\ncategory: personal\nsource_title: Future Goal\n"
+        "summary: ''\ntags: []\ncreated: '2026-01-01T09:00:00'\n"
+        "due_date: '2099-12-31'\nstatus: active\npriority: medium\n"
+        "linked_projects: []\nnotes: ''\n---\n\n## Notes\n"
+    )
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_goals(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "due 2099-12-31" in reply
+    assert "OVERDUE" not in reply
+
 @pytest.mark.asyncio
 async def test_cmd_reading_invalid_index_shows_registry_help(handler, brain_dir):
     """Invalid index in /reading shows Knowledge listings group help"""
@@ -3903,7 +3937,61 @@ async def test_dismiss_multiple_indices(handler, brain_dir):
         assert "Review design doc" in reply
         assert mock_update.call_count == 2
 
+# ── Overdue indicator in /commitments ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_commitments_overdue_shows_was_due(handler, brain_dir):
+    """/commitments marks past-due items with 'was due'."""
+    m = brain_dir / "memories"
+    write_commitment(m, "Overdue task", status="active", due_date="2024-01-01")
+
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_commitments(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "was due 2024-01-01" in reply
+    assert "⚠️" in reply
+
+
+@pytest.mark.asyncio
+async def test_commitments_future_due_shows_due(handler, brain_dir):
+    """/commitments shows 'due' (not 'was due') for future items."""
+    m = brain_dir / "memories"
+    write_commitment(m, "Future task", status="active", due_date="2099-12-31")
+
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_commitments(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "due 2099-12-31" in reply
+    assert "was due" not in reply
+
+
 # ── /todos command ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_cmd_todos_overdue_shows_was_due(handler, brain_dir):
+    """/todos marks overdue items with 'was due'."""
+    m = brain_dir / "memories"
+    write_commitment(m, "Overdue todo", status="active", due_date="2024-01-01")
+
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_todos(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "was due 2024-01-01" in reply
+    assert "⚠️" in reply
+
+
+@pytest.mark.asyncio
+async def test_cmd_todos_future_due_shows_due(handler, brain_dir):
+    """/todos shows 'due' for future items, not 'was due'."""
+    m = brain_dir / "memories"
+    write_commitment(m, "Future todo", status="active", due_date="2099-12-31")
+
+    update, context = _make_update(12345, args=[])
+    await handler.cmd_todos(update, context)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "due 2099-12-31" in reply
+    assert "was due" not in reply
+
 
 @pytest.mark.asyncio
 async def test_cmd_todos_empty_list(handler, brain_dir):
@@ -3918,7 +4006,7 @@ async def test_cmd_todos_empty_list(handler, brain_dir):
 async def test_cmd_todos_lists_with_checkbox_format(handler, brain_dir):
     """/todos shows commitments as [ ] checkboxes."""
     m = brain_dir / "memories"
-    write_commitment(m, "Send quarterly report", status="active", due_date="2026-05-01")
+    write_commitment(m, "Send quarterly report", status="active", due_date="2099-12-31")
     write_commitment(m, "Review design doc", status="active")
 
     update, context = _make_update(12345, args=[])
@@ -3927,7 +4015,7 @@ async def test_cmd_todos_lists_with_checkbox_format(handler, brain_dir):
     assert "Todos (2)" in reply
     assert "[ ] Send quarterly report" in reply
     assert "[ ] Review design doc" in reply
-    assert "due 2026-05-01" in reply
+    assert "due 2099-12-31" in reply
     assert "/todos done N" in reply
 
 
@@ -5249,6 +5337,26 @@ def test_list_projects_text_code_routes_to_code_repos(handler, brain_dir):
     text = handler._list_projects_text(category="code")
     assert "myrepo" in text
     assert "GoalManager Project" not in text
+
+
+def test_list_projects_text_overdue_shows_was_due(handler, brain_dir):
+    """_list_projects_text marks past-due active projects with 'was due … OVERDUE'."""
+    m = brain_dir / "memories"
+    _write_project_file(m, "work-overdue-abc123", "Overdue Project", due_date="2024-01-01")
+
+    text = handler._list_projects_text()
+    assert "was due 2024-01-01" in text
+    assert "OVERDUE" in text
+
+
+def test_list_projects_text_future_due_shows_due(handler, brain_dir):
+    """_list_projects_text shows plain 'due' for future-dated projects."""
+    m = brain_dir / "memories"
+    _write_project_file(m, "work-future-abc123", "Future Project", due_date="2099-12-31")
+
+    text = handler._list_projects_text()
+    assert "due 2099-12-31" in text
+    assert "OVERDUE" not in text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_install_manifest.py
+++ b/tests/unit/test_install_manifest.py
@@ -6,11 +6,8 @@ imported by an existing deployed module, but the author forgets to add it
 to the installer manifest — causing a ModuleNotFoundError crash loop at
 deploy time.
 """
-import ast
-import re
 from pathlib import Path
-
-REPO_ROOT = Path(__file__).parent.parent.parent
+from _manifest_helpers import REPO_ROOT, parse_daemon_files, _import_closure
 
 # .py files at repo root that are intentionally not deployed.
 # One-shot scripts, manual-run utilities, etc.
@@ -19,47 +16,9 @@ DO_NOT_DEPLOY = {
 }
 
 
-def _parse_daemon_files() -> set[str]:
-    """Extract the DAEMON_FILES array from install.sh."""
-    text = (REPO_ROOT / "install.sh").read_text()
-    m = re.search(r"DAEMON_FILES=\(\s*(.*?)\s*\)", text, re.DOTALL)
-    assert m, "Could not find DAEMON_FILES array in install.sh"
-    return set(m.group(1).split())
-
-
-def _local_imports(path: Path) -> set[str]:
-    """Return local-module names directly imported by path (non-recursive)."""
-    tree = ast.parse(path.read_text(), filename=str(path))
-    names = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                names.add(alias.name.split(".")[0])
-        elif isinstance(node, ast.ImportFrom):
-            if node.module and node.level == 0:
-                names.add(node.module.split(".")[0])
-    return {n for n in names if (REPO_ROOT / f"{n}.py").exists()}
-
-
-def _import_closure(entry: Path) -> set[str]:
-    """Compute the transitive closure of local-module imports from entry."""
-    visited: set[str] = set()
-    frontier = {entry.stem}
-    while frontier:
-        name = frontier.pop()
-        if name in visited:
-            continue
-        visited.add(name)
-        py = REPO_ROOT / f"{name}.py"
-        if py.exists():
-            frontier |= _local_imports(py)
-    # Return as filenames, not module names
-    return {f"{n}.py" for n in visited}
-
-
 # ── Shared state (computed once at module import) ──────────────────────────
 
-_daemon_files = _parse_daemon_files()
+_daemon_files = parse_daemon_files()
 _closure = _import_closure(REPO_ROOT / "daemon.py")
 
 

--- a/tests/unit/test_requirements_manifest.py
+++ b/tests/unit/test_requirements_manifest.py
@@ -1,0 +1,58 @@
+"""Verify requirements.txt covers every third-party import used by the daemon."""
+import re
+from pathlib import Path
+from _manifest_helpers import (
+    REPO_ROOT,
+    dist_for,
+    third_party_imports_in,
+)
+
+
+def _parse_requirements() -> set[str]:
+    """Return lowercased distribution names from requirements.txt."""
+    text = (REPO_ROOT / "requirements.txt").read_text()
+    pinned = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-r"):
+            continue
+        # Strip version specifier: pyyaml==6.0.2 -> pyyaml
+        name = re.split(r"[>=<!]", line)[0].strip().lower().replace("_", "-")
+        pinned.add(name)
+    return pinned
+
+
+# Compute once at import (fast, pure AST)
+_third_party = third_party_imports_in(["daemon"])  # full closure from daemon.py entry
+_pinned = _parse_requirements()
+
+
+def test_every_third_party_import_in_requirements():
+    """Each third-party import reachable from daemon.py must have a requirements.txt pin."""
+    missing = sorted(
+        name for name in _third_party
+        if dist_for(name) not in _pinned
+    )
+    assert not missing, (
+        f"These imports are used by the daemon but have no matching pin in "
+        f"requirements.txt: {missing}. Add the distribution to requirements.txt "
+        f"or add a mapping to IMPORT_TO_DISTRIBUTION in _manifest_helpers.py."
+    )
+
+
+def test_no_unused_requirements():
+    """Every requirements.txt pin must map to at least one import (or be in ALLOWLIST)."""
+    # Some packages may be runtime-only deps that never appear in import statements
+    # (e.g., a litellm backend provider that's only referenced by string config).
+    UNIMPORTED_BUT_NEEDED: set[str] = {
+        "lxml",      # Used by BeautifulSoup as parser: BeautifulSoup(html, "lxml")
+        "watchdog",  # Used by litellm file watcher (if enabled in config)
+    }
+
+    used = {dist_for(n) for n in _third_party}
+    extra = sorted(_pinned - used - UNIMPORTED_BUT_NEEDED)
+    assert not extra, (
+        f"requirements.txt entries not imported anywhere in the daemon: {extra}. "
+        f"Either remove the pin from requirements.txt or add to "
+        f"UNIMPORTED_BUT_NEEDED in this test if it's a runtime-only dep."
+    )

--- a/tests/unit/test_watcher_role_packages.py
+++ b/tests/unit/test_watcher_role_packages.py
@@ -1,0 +1,44 @@
+"""Verify watcher-role import closure stays within watcher-installed packages."""
+import re
+from pathlib import Path
+from _manifest_helpers import REPO_ROOT, dist_for, third_party_imports_in
+
+WATCHER_ENTRY_POINTS = [
+    "browser_watcher",
+    "code_scanner",
+    "email_scanner",
+    "calendar_scanner",
+    "slack_scanner",
+    "memory_cache",
+]
+
+
+def _parse_watcher_pip_list() -> set[str]:
+    """Extract the watcher-role pip install list from install.sh."""
+    text = (REPO_ROOT / "install.sh").read_text()
+    # Matches the inline: pip install -q litellm httpx beautifulsoup4 ...
+    # inside the if [ "$ROLE" = "watcher" ] block (line ~513)
+    m = re.search(r'\$VENV/bin/pip.*install -q (litellm\s+httpx[^\n]+)', text)
+    assert m, "Could not find watcher pip install list in install.sh"
+    packages = m.group(1).strip().split()
+    return {p.lower().replace("_", "-") for p in packages}
+
+
+_watcher_third_party = third_party_imports_in(WATCHER_ENTRY_POINTS)
+_watcher_pkgs = _parse_watcher_pip_list()
+
+
+def test_watcher_closure_third_party_subset_of_watcher_packages():
+    """Every third-party import reachable from watcher-role modules must be
+    in the watcher pip install list in install.sh."""
+    leaked = sorted(
+        name for name in _watcher_third_party
+        if dist_for(name) not in _watcher_pkgs
+    )
+    assert not leaked, (
+        f"These third-party packages are reachable from watcher-role modules "
+        f"but are NOT in install.sh's watcher pip list (line ~513): {leaked}. "
+        f"Options: (a) move the import inside the role-gated code path, "
+        f"(b) add the package to the watcher pip install list in install.sh, "
+        f"or (c) factor the offending code out of the watcher import path."
+    )


### PR DESCRIPTION
## Summary

- `/commitments` and `/todos` showed `due 2026-04-15` for stale items with no visual cue that the date had already passed — users saw the raw past date without any indication the item was overdue.
- Same gap existed in `/goals` (partial fix existed for "within 7 days" but not for negative `days_until`) and `/projects` (no indicator at all).
- Now any active item whose `due_date` is in the past renders as `was due <date> ⚠️` (commitments/todos) or `was due <date> ⚠️ OVERDUE` (goals/projects), matching the `was due` wording already used in the daily morning briefing's Overdue section for consistency.

## Test plan

- [x] Added `test_commitments_overdue_shows_was_due` — verifies `was due` + `⚠️` in `/commitments` output for past-due item
- [x] Added `test_commitments_future_due_shows_due` — verifies no `was due` for future-dated item
- [x] Added `test_cmd_todos_overdue_shows_was_due` — same for `/todos`
- [x] Added `test_cmd_todos_future_due_shows_due`
- [x] Added `test_cmd_goals_overdue_shows_was_due` — verifies `was due` + `OVERDUE` in `/goals`
- [x] Added `test_cmd_goals_future_due_shows_due`
- [x] Added `test_list_projects_text_overdue_shows_was_due` — verifies `_list_projects_text` overdue indicator
- [x] Added `test_list_projects_text_future_due_shows_due`
- [x] `pytest` full suite — 1460 passed

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)