### PR TITLE
Fix /bugs and /features list to include 6-char hash ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `/bugs` and `/features` list entries now include the 6-character hash ID (e.g. `[abc123]`) so users can reference items by ID in follow-up commands like `/feature_detail` (#131).
+
 ## [1.14.0] — 2026-05-10
 
 ### Added

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -5447,7 +5447,9 @@ class TelegramChatHandler:
             created = fm.get("created", "")[:10]
             item_kind = fm.get("kind", "feature")
             kind_tag = f"[{item_kind[:4]}] " if not kind else ""
-            lines.append(f"{i}. {kind_tag}[{item_status}] [{priority}] {title} ({created})")
+            short_id = fm.get("short_id", "")
+            id_suffix = f" [{short_id}]" if short_id else ""
+            lines.append(f"{i}. {kind_tag}[{item_status}] [{priority}] {title} ({created}){id_suffix}")
         return "\n".join(lines)
 
     def _get_memory_text(self, name: str) -> str:
@@ -6079,7 +6081,9 @@ class TelegramChatHandler:
             created = fm.get("created", "")[:10]
             item_kind = fm.get("kind", "feature")
             kind_tag = f"[{item_kind[:4]}] " if not kind_filter else ""
-            lines.append(f"{i}. {kind_tag}[{status}] [{priority}] {title} ({created})")
+            short_id = fm.get("short_id", "")
+            id_suffix = f" [{short_id}]" if short_id else ""
+            lines.append(f"{i}. {kind_tag}[{status}] [{priority}] {title} ({created}){id_suffix}")
 
         await self._send_reply(update, "\n".join(lines))
 

--- a/tests/unit/test_chat_handler.py
+++ b/tests/unit/test_chat_handler.py
@@ -1910,6 +1910,7 @@ async def test_features_kind_filter_bug(handler, brain_dir):
     reply = update.message.reply_text.call_args[0][0]
     assert len(handler._last_feature_set) == 1
     assert handler._last_feature_set[0] == bug_path
+    assert "aaa111" in reply
 
 
 async def test_features_kind_filter_feature(handler, brain_dir):
@@ -1952,6 +1953,34 @@ async def test_bugs_alias_lists_bugs_only(handler, brain_dir):
     await handler.cmd_bugs(update, ctx)
     assert len(handler._last_feature_set) == 1
     assert handler._last_feature_set[0] == bug_path
+
+
+async def test_bugs_list_includes_short_id(handler, brain_dir):
+    """Each entry in /bugs output must include the 6-character hash ID."""
+    m = brain_dir / "memories"
+    (m / "feature-request-crash-abc123.md").write_text(
+        "---\ntitle: Crash on startup\ntype: feature_request\nkind: bug\n"
+        "status: new\npriority: high\ncreated: '2026-05-01T09:00:00'\n"
+        "tags: []\nshort_id: abc123\n---\n\n## Bug\nApp crashes"
+    )
+    update, ctx = _make_update(12345)
+    await handler.cmd_bugs(update, ctx)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "abc123" in reply
+
+
+async def test_features_list_includes_short_id(handler, brain_dir):
+    """Each entry in /features output must include the 6-character hash ID."""
+    m = brain_dir / "memories"
+    (m / "feature-request-dark-mode-def456.md").write_text(
+        "---\ntitle: Dark mode support\ntype: feature_request\nkind: feature\n"
+        "status: new\npriority: medium\ncreated: '2026-05-01T09:00:00'\n"
+        "tags: []\nshort_id: def456\n---\n\n## Request\nAdd dark mode"
+    )
+    update, ctx = _make_update(12345)
+    await handler.cmd_features(update, ctx)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "def456" in reply
 
 
 # ── GitHub client tests ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `/bugs` and `/features` list entries were missing the 6-character hash ID (e.g. `[abc123]`), making it impossible to reference items by ID without first running `/feature_detail`
- Fixed both `cmd_features` inline list builder and the `_list_features_text` helper (used by tool dispatch) to include the `short_id` suffix
- Added two new tests asserting the hash appears in output; updated an existing test with the same assertion

## Test plan
- [ ] `pytest tests/unit/test_chat_handler.py::test_bugs_list_includes_short_id` passes
- [ ] `pytest tests/unit/test_chat_handler.py::test_features_list_includes_short_id` passes
- [ ] `pytest tests/unit/test_chat_handler.py::test_features_kind_filter_bug` passes (asserts hash in reply)
- [ ] Full `pytest` suite passes (1661 tests, 1 pre-existing unrelated failure in email scanner integration test)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)