### PR TITLE
Fix calendar change detection — NULL ZMODIFIEDDATE caused infinite re-ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `/bugs` and `/features` list entries now include the 6-character hash ID (e.g. `[abc123]`) so users can reference items by ID in follow-up commands like `/feature_detail` (#131).
+
 ## [1.14.0] — 2026-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - `/bugs` and `/features` list entries now include the 6-character hash ID (e.g. `[abc123]`) so users can reference items by ID in follow-up commands like `/feature_detail` (#131).
+- Calendar events with a NULL `ZMODIFIEDDATE` (common for all-day and recurring events) were using `datetime.now()` as the modification timestamp fallback, causing those events to appear "updated" on every scan cycle and be re-ingested every 5 minutes. Fixed by using `_cd_to_datetime(modified_cd)` directly, which maps null/zero to the stable epoch `datetime(2001, 1, 1)` (#126).
 
 ## [1.14.0] — 2026-05-10
 

--- a/calendar_scanner.py
+++ b/calendar_scanner.py
@@ -309,7 +309,7 @@ class CalendarCacheSource(CalendarDataSource):
                     "title": title or "Untitled Event",
                     "start_time": _cd_to_datetime(start_cd) if start_cd else datetime.now(),
                     "end_time": _cd_to_datetime(end_cd) if end_cd else datetime.now(),
-                    "modified_time": _cd_to_datetime(modified_cd) if modified_cd else datetime.now(),
+                    "modified_time": _cd_to_datetime(modified_cd),  # None/0 → epoch; stable across scans
                     "location": location or "",
                     "notes": notes or "",
                     "all_day": bool(all_day),

--- a/chat_handler.py
+++ b/chat_handler.py
@@ -5447,7 +5447,9 @@ class TelegramChatHandler:
             created = fm.get("created", "")[:10]
             item_kind = fm.get("kind", "feature")
             kind_tag = f"[{item_kind[:4]}] " if not kind else ""
-            lines.append(f"{i}. {kind_tag}[{item_status}] [{priority}] {title} ({created})")
+            short_id = fm.get("short_id", "")
+            id_suffix = f" [{short_id}]" if short_id else ""
+            lines.append(f"{i}. {kind_tag}[{item_status}] [{priority}] {title} ({created}){id_suffix}")
         return "\n".join(lines)
 
     def _get_memory_text(self, name: str) -> str:
@@ -6079,7 +6081,9 @@ class TelegramChatHandler:
             created = fm.get("created", "")[:10]
             item_kind = fm.get("kind", "feature")
             kind_tag = f"[{item_kind[:4]}] " if not kind_filter else ""
-            lines.append(f"{i}. {kind_tag}[{status}] [{priority}] {title} ({created})")
+            short_id = fm.get("short_id", "")
+            id_suffix = f" [{short_id}]" if short_id else ""
+            lines.append(f"{i}. {kind_tag}[{status}] [{priority}] {title} ({created}){id_suffix}")
 
         await self._send_reply(update, "\n".join(lines))
 

--- a/tests/unit/test_calendar_scanner.py
+++ b/tests/unit/test_calendar_scanner.py
@@ -559,6 +559,67 @@ def test_skip_calendars_filtered(tmp_path):
     assert len(events) == 0
 
 
+def test_null_modified_date_stable(tmp_path):
+    """NULL ZMODIFIEDDATE → stable modified_time of datetime(2001,1,1), not datetime.now().
+
+    When ZMODIFIEDDATE is NULL (as is common for all-day and recurring events),
+    _cd_to_datetime returns datetime(2001,1,1) — a fixed epoch. The old code
+    used datetime.now() as fallback, which caused events to be re-processed
+    every scan cycle because the stored modified_str never matched the next
+    cycle's datetime.now() value (#126).
+    """
+    db_path = tmp_path / "Calendar Cache"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE ZCALENDAR (Z_PK INTEGER PRIMARY KEY, ZTITLE TEXT)")
+    conn.execute("""
+        CREATE TABLE ZCALENDARITEM (
+            Z_PK INTEGER PRIMARY KEY,
+            ZTITLE TEXT,
+            ZSTARTDATE REAL,
+            ZENDDATE REAL,
+            ZMODIFIEDDATE REAL,
+            ZLOCATION TEXT,
+            ZNOTES TEXT,
+            ZISALLDAY INTEGER,
+            ZHASRECURRENCERULES INTEGER,
+            ZMYATTENDEESTATUS INTEGER,
+            ZEXTERNALIDENTIFIER TEXT,
+            ZCALENDAR INTEGER
+        )
+    """)
+    conn.execute("CREATE TABLE ZATTENDEE (ZCOMMONNAME TEXT, ZADDRESS TEXT, ZCALENDARITEM INTEGER)")
+    conn.execute("INSERT INTO ZCALENDAR (Z_PK, ZTITLE) VALUES (1, 'Work')")
+
+    now = datetime.now()
+    event_start = now + timedelta(days=1)
+    start_cd = _datetime_to_cd(event_start)
+    end_cd = _datetime_to_cd(event_start + timedelta(hours=1))
+
+    # Insert event with NULL ZMODIFIEDDATE (None → SQLite NULL)
+    conn.execute(
+        "INSERT INTO ZCALENDARITEM VALUES (1, 'All Day Event', ?, ?, NULL, '', '', 1, 0, 0, 'ext1', 1)",
+        (start_cd, end_cd)
+    )
+    conn.commit()
+    conn.close()
+
+    # Make a copy so the finally block in get_events can delete it without losing the DB
+    db_copy = tmp_path / "Calendar Cache Copy"
+    import shutil as _shutil
+    _shutil.copy2(str(db_path), str(db_copy))
+
+    source = CalendarCacheSource(db_copy)
+    start_date = now - timedelta(days=7)
+    end_date = now + timedelta(days=7)
+
+    with patch.object(source, '_copy_db', return_value=(db_copy, [])):
+        events = source.get_events(start_date, end_date, set())
+
+    assert len(events) == 1
+    # modified_time must be the stable epoch date, not near-current time
+    assert events[0]["modified_time"] == datetime(2001, 1, 1)
+
+
 # ── Change detection ──────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chat_handler.py
+++ b/tests/unit/test_chat_handler.py
@@ -1910,6 +1910,7 @@ async def test_features_kind_filter_bug(handler, brain_dir):
     reply = update.message.reply_text.call_args[0][0]
     assert len(handler._last_feature_set) == 1
     assert handler._last_feature_set[0] == bug_path
+    assert "aaa111" in reply
 
 
 async def test_features_kind_filter_feature(handler, brain_dir):
@@ -1952,6 +1953,34 @@ async def test_bugs_alias_lists_bugs_only(handler, brain_dir):
     await handler.cmd_bugs(update, ctx)
     assert len(handler._last_feature_set) == 1
     assert handler._last_feature_set[0] == bug_path
+
+
+async def test_bugs_list_includes_short_id(handler, brain_dir):
+    """Each entry in /bugs output must include the 6-character hash ID."""
+    m = brain_dir / "memories"
+    (m / "feature-request-crash-abc123.md").write_text(
+        "---\ntitle: Crash on startup\ntype: feature_request\nkind: bug\n"
+        "status: new\npriority: high\ncreated: '2026-05-01T09:00:00'\n"
+        "tags: []\nshort_id: abc123\n---\n\n## Bug\nApp crashes"
+    )
+    update, ctx = _make_update(12345)
+    await handler.cmd_bugs(update, ctx)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "abc123" in reply
+
+
+async def test_features_list_includes_short_id(handler, brain_dir):
+    """Each entry in /features output must include the 6-character hash ID."""
+    m = brain_dir / "memories"
+    (m / "feature-request-dark-mode-def456.md").write_text(
+        "---\ntitle: Dark mode support\ntype: feature_request\nkind: feature\n"
+        "status: new\npriority: medium\ncreated: '2026-05-01T09:00:00'\n"
+        "tags: []\nshort_id: def456\n---\n\n## Request\nAdd dark mode"
+    )
+    update, ctx = _make_update(12345)
+    await handler.cmd_features(update, ctx)
+    reply = update.message.reply_text.call_args[0][0]
+    assert "def456" in reply
 
 
 # ── GitHub client tests ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `CalendarCacheSource.get_events()` used `datetime.now()` as the fallback when `ZMODIFIEDDATE` was NULL (common for all-day and recurring events). Since `datetime.now()` changes every second, the stored `modified_str` never matched the value computed on the next scan cycle.
- This caused those events to always appear "updated" and be re-ingested every 5 minutes — wasting LLM calls and never settling into "already current" state (#126).
- Fix: call `_cd_to_datetime(modified_cd)` directly; it already maps `null`/`0` to the stable epoch `datetime(2001, 1, 1)`, so the stored modified string is now consistent across scans.

## Test plan

- [ ] `test_null_modified_date_stable` — new test verifies NULL `ZMODIFIEDDATE` produces `datetime(2001, 1, 1)`, not the current time
- [ ] All 57 calendar scanner tests pass
- [ ] Full pytest suite passes (1662 tests)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)