### PR TITLE
Add quota_scrapers unit tests and pip audit CVE scan (#113, #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Dependency CVE scan** (`install.sh`): step 19 now runs `pip audit` against the deploy venv after every install, printing any known CVEs and warning (non-blocking) when vulnerabilities are found. `pip-audit` is installed on-demand into the venv if not already present (#113).
+- **Unit tests for `quota_scrapers.py`** (`tests/unit/test_quota_scrapers.py`): four tests cover missing-cookie-file guard (returns `{}`) and the not-yet-implemented scraping stub (raises `NotImplementedError` when cookie exists). `scrape_claude` and `scrape_chatgpt` now return `{}` immediately when the cookie file is absent instead of proceeding to the `NotImplementedError` raise (#114).
 - **Pre-commit hook** (`hooks/pre-commit`): running `install.sh` now installs a git pre-commit hook that gates every commit behind the full pytest suite. The hook uses the deploy venv when available, falls back to system pytest, and skips gracefully on a fresh clone before venv exists. Addresses gap #3 (P1) from the test coverage assessment (#111).
 
 ### Fixed

--- a/install.sh
+++ b/install.sh
@@ -899,7 +899,7 @@ echo "Checking for known CVEs in dependencies..."
 if ! "$VENV/bin/pip" show pip-audit &>/dev/null; then
     "$VENV/bin/pip" install -q pip-audit
 fi
-CVE_OUTPUT=$("$VENV/bin/pip-audit" --format columns 2>&1)
+CVE_OUTPUT=$("$VENV/bin/pip-audit" --format columns 2>&1) || true
 CVE_EXIT=$?
 if [ $CVE_EXIT -eq 0 ]; then
     ok "No known CVEs found"

--- a/install.sh
+++ b/install.sh
@@ -899,10 +899,16 @@ echo "Checking for known CVEs in dependencies..."
 if ! "$VENV/bin/pip" show pip-audit &>/dev/null; then
     "$VENV/bin/pip" install -q pip-audit
 fi
-if "$VENV/bin/pip" audit --format columns 2>/dev/null; then
+CVE_OUTPUT=$("$VENV/bin/pip-audit" --format columns 2>&1)
+CVE_EXIT=$?
+if [ $CVE_EXIT -eq 0 ]; then
     ok "No known CVEs found"
+elif [ $CVE_EXIT -eq 1 ]; then
+    echo "$CVE_OUTPUT"
+    printf "${YELLOW}  !${NC}  pip-audit found vulnerabilities above — review before deploying\n"
 else
-    printf "${YELLOW}  !${NC}  pip audit found vulnerabilities above — review before deploying\n"
+    echo "$CVE_OUTPUT"
+    printf "${YELLOW}  !${NC}  pip-audit exited with code $CVE_EXIT — scan may not have completed\n"
 fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -893,6 +893,18 @@ else
     skip "hooks/pre-commit not found in repo — skipping"
 fi
 
+# ── 19. Dependency CVE scan ───────────────────────────────────────────────────
+echo ""
+echo "Checking for known CVEs in dependencies..."
+if ! "$VENV/bin/pip" show pip-audit &>/dev/null; then
+    "$VENV/bin/pip" install -q pip-audit
+fi
+if "$VENV/bin/pip" audit --format columns 2>/dev/null; then
+    ok "No known CVEs found"
+else
+    printf "${YELLOW}  !${NC}  pip audit found vulnerabilities above — review before deploying\n"
+fi
+
 # ── Done ──────────────────────────────────────────────────────────────────────
 echo ""
 echo "  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/install.sh
+++ b/install.sh
@@ -899,7 +899,7 @@ echo "Checking for known CVEs in dependencies..."
 if ! "$VENV/bin/pip" show pip-audit &>/dev/null; then
     "$VENV/bin/pip" install -q pip-audit
 fi
-CVE_OUTPUT=$("$VENV/bin/pip-audit" --format columns 2>&1) || true
+CVE_OUTPUT=$("$VENV/bin/pip-audit" --format columns 2>&1)
 CVE_EXIT=$?
 if [ $CVE_EXIT -eq 0 ]; then
     ok "No known CVEs found"

--- a/quota_scrapers.py
+++ b/quota_scrapers.py
@@ -20,11 +20,14 @@ async def scrape_claude(cookie_path: Path) -> dict:
         cookie_path: Path to saved session cookie file
 
     Returns:
-        dict with keys: used, cap, window_resets_at (ISO timestamp)
+        dict with keys: used, cap, window_resets_at (ISO timestamp).
+        Returns {} if the cookie file is missing.
 
     Raises:
-        NotImplementedError: Scraping not yet implemented
+        NotImplementedError: Scraping is not yet implemented.
     """
+    if not cookie_path.exists():
+        return {}
     raise NotImplementedError(
         "Scraping not yet implemented; use /quota report for self-report."
     )
@@ -37,11 +40,14 @@ async def scrape_chatgpt(cookie_path: Path) -> dict:
         cookie_path: Path to saved session cookie file
 
     Returns:
-        dict with keys: used, cap, window_resets_at (ISO timestamp)
+        dict with keys: used, cap, window_resets_at (ISO timestamp).
+        Returns {} if the cookie file is missing.
 
     Raises:
-        NotImplementedError: Scraping not yet implemented
+        NotImplementedError: Scraping is not yet implemented.
     """
+    if not cookie_path.exists():
+        return {}
     raise NotImplementedError(
         "Scraping not yet implemented; use /quota report for self-report."
     )

--- a/tests/unit/test_quota_scrapers.py
+++ b/tests/unit/test_quota_scrapers.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for quota_scrapers.py.
+
+The scraping functions are intentional stubs — actual HTTP scraping is
+not implemented. These tests cover the pre-flight guards and document the
+expected failure-path behaviour so that a future implementation can't
+accidentally regress to raising on inputs that should silently return {}.
+"""
+import pytest
+
+from quota_scrapers import scrape_claude, scrape_chatgpt
+
+
+# ── scrape_claude ─────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_scrape_claude_missing_cookie_file(tmp_path):
+    """Returns {} when cookie file does not exist — never raises."""
+    result = await scrape_claude(tmp_path / "missing.json")
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_scrape_claude_not_implemented_when_cookie_present(tmp_path):
+    """Raises NotImplementedError when cookie file exists (scraping stub)."""
+    cookie = tmp_path / "cookies.json"
+    cookie.write_text("{}")
+    with pytest.raises(NotImplementedError):
+        await scrape_claude(cookie)
+
+
+# ── scrape_chatgpt ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_scrape_chatgpt_missing_cookie_file(tmp_path):
+    """Returns {} when cookie file does not exist — never raises."""
+    result = await scrape_chatgpt(tmp_path / "missing.json")
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_scrape_chatgpt_not_implemented_when_cookie_present(tmp_path):
+    """Raises NotImplementedError when cookie file exists (scraping stub)."""
+    cookie = tmp_path / "cookies.json"
+    cookie.write_text("{}")
+    with pytest.raises(NotImplementedError):
+        await scrape_chatgpt(cookie)


### PR DESCRIPTION
## Summary

- **`quota_scrapers.py`**: added missing-cookie-file pre-flight guard — both `scrape_claude` and `scrape_chatgpt` now return `{}` immediately when the cookie path does not exist, satisfying the failure-path contract from issue #114.
- **`tests/unit/test_quota_scrapers.py`**: four new tests covering the pre-flight guard (`missing cookie → {}`) and the not-yet-implemented stub behaviour (`cookie present → NotImplementedError`).
- **`install.sh`**: new step 19 runs `pip audit` against the deploy venv after every install. `pip-audit` is installed on-demand into the venv if not already present. Non-blocking — prints a warning on findings but does not abort the install (#113).

## Test plan

- [x] `pytest tests/unit/test_quota_scrapers.py` — 4 new tests pass
- [x] Full test suite (711 passed, 0 failed)
- [x] `pip audit` runs correctly against the venv

Closes #113
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)